### PR TITLE
smarter segment source logic — skip DB storage when Strava already ha…

### DIFF
--- a/src/routers/activities_router.ts
+++ b/src/routers/activities_router.ts
@@ -32,6 +32,7 @@ const querySchema = z.object({
 	search: z.string().optional(),
 	distance: z.coerce.number().optional(),
 	trainingType: z.enum(trainingTypeEnum.enumValues).optional(),
+	intervalStructureId: z.coerce.number().int().positive().optional(),
 });
 
 activitiesRouter.get(
@@ -55,7 +56,7 @@ activitiesRouter.get(
 	async (c) => {
 		try {
 			const userId = c.get("userId");
-			const { page, search, distance, trainingType } = c.req.valid("query");
+			const { page, search, distance, trainingType, intervalStructureId } = c.req.valid("query");
 			const filters = [];
 			filters.push(eq(activities.userId, userId));
 			filters.push(eq(activities.analysisStatus, "completed"));
@@ -75,6 +76,9 @@ activitiesRouter.get(
 					filters.push(gte(activities.distance, distance));
 				}
 			}
+			if (intervalStructureId) {
+				filters.push(eq(activities.intervalStructureId, intervalStructureId));
+			}
 			const result = await c.env.db
 				.select()
 				.from(activities)
@@ -87,7 +91,7 @@ activitiesRouter.get(
 				meta: {
 					page,
 					pageSize: PAGE_SIZE,
-					filterApplied: { search, trainingType, distance: distance },
+					filterApplied: { search, trainingType, distance, intervalStructureId },
 				},
 			});
 		} catch (error) {
@@ -96,6 +100,7 @@ activitiesRouter.get(
 		}
 	},
 );
+
 activitiesRouter.get(
 	"/:id/segments",
 	describeRoute({
@@ -120,7 +125,6 @@ activitiesRouter.get(
 	async (c) => {
 		try {
 			const activityId = parseInt(c.req.param("id"));
-			console.log(`AcitityDetails for${activityId} `);
 			if (isNaN(activityId)) {
 				return c.json({ error: "Invalid activity ID" }, 400);
 			}
@@ -129,10 +133,7 @@ activitiesRouter.get(
 				.from(intervalSegments)
 				.where(eq(intervalSegments.activityId, activityId))
 				.orderBy(asc(intervalSegments.segmentIndex));
-
-			return c.json({
-				intervalSegments: segments,
-			});
+			return c.json({ intervalSegments: segments });
 		} catch (error) {
 			console.error("Error fetching activity:", error);
 			return c.json({ error: "Internal Server Error" }, 500);

--- a/src/schemas/api_schemas.ts
+++ b/src/schemas/api_schemas.ts
@@ -44,6 +44,7 @@ export const ActivityListResponseSchema = z.object({
       search: z.string().optional(),
       trainingType: z.enum(trainingTypeEnum.enumValues).optional(),
       distance: z.number().optional(),
+      intervalStructureId: z.number().optional(),
     }),
   }),
 });

--- a/src/services.ts/analysis_service.ts
+++ b/src/services.ts/analysis_service.ts
@@ -4,7 +4,6 @@ import {
   activities,
   findOrCreateIntervalStructure,
   generateIntervalSignature,
-  getDbInsertIntervalSegmentsFromStravaMetrics,
   intervalSegments,
   intervalStructures,
   mapSetsToIntervalComponent,
@@ -13,7 +12,7 @@ import { IGlobalBindings } from "../types/IRouters";
 import { DetailedActivity } from "../types/strava/IDetailedActivity";
 import { stravaApiService } from "./strava_api_service";
 import { invokeCompleteActivityAnalysisAgent } from "../agent/full_analysis_agent";
-import { calculateSegmentStats, couldSkipCompleteAnalysis, generateCompleteIntervalSet, needCompleteAnalysis, parsePaceStringToMetersPerSecond } from "./utils";
+import { calculateSegmentStats, couldSkipCompleteAnalysis, generateCompleteIntervalSet, lapsMatchIntervals, needCompleteAnalysis, parsePaceStringToMetersPerSecond } from "./utils";
 import z from "zod";
 import { sleep } from "bun";
 import { ExpandedIntervalSet, } from "../types/ExpandedIntervalSet";
@@ -67,25 +66,34 @@ export const triggerInitialAnalysis = async (
         draftAnalysisResult: analysisResult,
         analysisVersion : "v2.0",
       };
-      const couldSkip = couldSkipCompleteAnalysis(analysisResult);
-      const finalUpdateObject = couldSkip
-        ? {
-            ...baseUpdate,
-            trainingType: analysisResult.training_type,
-            analysisStatus: "completed" as const,
+      if (couldSkipCompleteAnalysis(analysisResult)) {
+        // Easy/long/normal run — no segments stored, frontend fetches from Strava splits
+        await db.update(activities).set({
+          ...baseUpdate,
+          trainingType: analysisResult.training_type,
+          analysisStatus: "completed" as const,
+        }).where(eq(activities.id, activityId));
+      } else if (needCompleteAnalysis(analysisResult.training_type)) {
+        if (currentStravaActivity!.trainer) {
+          // Indoor interval — always need LLM analysis (GPS pace is unreliable)
+          await db.update(activities).set(baseUpdate).where(eq(activities.id, activityId));
+        } else {
+          // Outdoor interval — check if Strava laps already capture the structure
+          const laps = await stravaApiService.getActivityLaps(accessToken, stravaId);
+          if (lapsMatchIntervals(laps, analysisResult)) {
+            // Laps match — no segments stored, frontend fetches from Strava laps
+            await db.update(activities).set({
+              ...baseUpdate,
+              trainingType: analysisResult.training_type,
+              analysisStatus: "completed" as const,
+            }).where(eq(activities.id, activityId));
+          } else {
+            await db.update(activities).set(baseUpdate).where(eq(activities.id, activityId));
           }
-        : baseUpdate;
-      await db
-        .update(activities)
-        .set(finalUpdateObject)
-        .where(eq(activities.id, activityId));
-      if (couldSkip) {
-        await setStravaMetricsAsIntervalSegments(
-          db,
-          "",
-          activityId,stravaId,
-          accessToken
-        );
+        }
+      } else {
+        // Other types (TEMPO, RACE, RECOVERY, etc.) — wait for user to trigger complete
+        await db.update(activities).set(baseUpdate).where(eq(activities.id, activityId));
       }
       return analysisResult;
     }
@@ -152,13 +160,11 @@ export const triggerCompleteAnalysis = async (
       );
     }
     if (!needCompleteAnalysis(result.trainingType)) {
-      return await setStravaMetricsAsIntervalSegments(
-        db,
-        notes,
-        activityId,
-        stravaId,
-        accessToken
-      );
+      await db.update(activities).set({
+        analysisStatus: "completed",
+        notes: notes,
+      }).where(eq(activities.id, activityId));
+      return;
     }
 const streams = await stravaApiService.getActivityStreams(
   accessToken,
@@ -260,37 +266,6 @@ const streams = await stravaApiService.getActivityStreams(
       error
     );
     return null;
-  }
-};
-
-const setStravaMetricsAsIntervalSegments = async (
-  db: IGlobalBindings["db"],
-  notes: string,
-  activityId: number,
-  stravaId: number,
-  accessToken: string
-) => {
-  await db
-    .update(activities)
-    .set({
-      analysisStatus: "completed",
-      notes: notes,
-    })
-    .where(eq(activities.id, activityId));
-  const stravaActivity = await stravaApiService.getActivity(
-    accessToken,
-    stravaId
-  );
-  const splits = stravaActivity.splits_metric ??[];
-  if (splits.length > 0) {
-    await db
-      .insert(intervalSegments)
-      .values(
-        getDbInsertIntervalSegmentsFromStravaMetrics(
-          activityId,
-          splits ??[]
-        )
-      );
   }
 };
 

--- a/src/services.ts/utils.ts
+++ b/src/services.ts/utils.ts
@@ -3,6 +3,7 @@ import { WorkoutAnalysisOutput, workoutSet, } from "../agent/initial_analysis_ag
 import { TrainingType } from "../schema";
 import { LLMActivitySummary } from "../types/LLMActivitySummary";
 import { ActivityDataPoint, StreamSet } from "../types/strava/IStream";
+import { Lap } from "../types/strava/IDetailedActivity";
 
 export function shouldAnalyze(sportType: string): boolean {
   const runningTypes = ["Run", "TrailRun", "VirtualRun", "Elliptical", "Hike", "Ride", "Virtual Ride", "Rowing","Nordic Ski", "Backcountry Ski"];
@@ -24,6 +25,18 @@ export const couldSkipCompleteAnalysis = (result: WorkoutAnalysisOutput)=>{
   'EASY_RUN',
   "NORMAL_RUN",]
   return result.confidence_score > 0.94 && running.includes(result.training_type);
+}
+
+export function lapsMatchIntervals(laps: Lap[], draft: WorkoutAnalysisOutput): boolean {
+  if (!draft.structure || draft.structure.length === 0) return false;
+  if (laps.length <= 1) return false;
+  let expectedWorkIntervals = 0;
+  for (const set of draft.structure) {
+    for (const step of set.steps) {
+      expectedWorkIntervals += set.set_reps * step.reps;
+    }
+  }
+  return laps.length >= expectedWorkIntervals;
 }
 
 

--- a/src/types/strava/IDetailedActivity.ts
+++ b/src/types/strava/IDetailedActivity.ts
@@ -144,6 +144,8 @@ export interface Lap {
   average_cadence: number;
   device_watts: boolean;
   average_watts: number;
+  average_heartrate?: number;
+  max_heartrate?: number;
   lap_index: number;
   split: number;
 }


### PR DESCRIPTION
…s the structure

- Easy/long/normal runs no longer store splits_metric in DB; frontend fetches from Strava
- Outdoor interval activities check if Strava laps match the expected interval count; if they do, skip LLM complete analysis and let frontend use Strava laps directly
- Indoor interval activities always require LLM complete analysis (GPS pace unreliable)
- Add lapsMatchIntervals() utility to compare Strava lap count vs expected work intervals
- Add optional heartrate fields to Lap type
- Add intervalStructureId filter to activity list endpoint