### PR TITLE
feat(analysis): feed deterministic lap evidence to the session classifier

### DIFF
--- a/scripts/ab_model.ts
+++ b/scripts/ab_model.ts
@@ -105,6 +105,7 @@ async function main() {
           act.totalElevationGain ?? 0,
           act.sportType ?? "Run",
           pred,
+          dump.pipeline?.laps ?? [],
           model,
         );
         const type = res?.training_type ?? null;

--- a/scripts/audit_classify.ts
+++ b/scripts/audit_classify.ts
@@ -1,0 +1,125 @@
+import { sleep } from "bun";
+import { readdirSync } from "fs";
+import { invokeActivityAnalysisAgent } from "../src/agent/initial_analysis_agent";
+import { buildLapEvidenceBlock } from "../src/agent/lap_evidence";
+
+/**
+ * Full-corpus classifier audit. Runs the REAL classifier (with the lap-evidence
+ * hint) on every activity-*.json dump, then flags anomalies: committed-vs-classified
+ * disagreement, title-implies-intervals-but-got-EASY, lap-evidence-fired-but-got-EASY.
+ * Read-only; no DB. Run: bun run scripts/audit_classify.ts
+ */
+
+const DUMP =
+  process.env.DUMP ??
+  "/Users/carlvaldemarebbesen/Development/intervals/knowledge/knowledge/sources/activity-dumps";
+const DELAY_MS = Number(process.env.DELAY_MS ?? 700);
+
+const INTERVAL_TYPES = new Set([
+  "SHORT_INTERVALS",
+  "LONG_INTERVALS",
+  "SPRINTS",
+  "HILL_SPRINTS",
+  "TEMPO",
+  "FARTLEK",
+  "PROGRESSIVE_LONG",
+]);
+
+function toStreamSet(s: any) {
+  const wrap = (arr: any) => (Array.isArray(arr) ? { data: arr } : undefined);
+  return {
+    time: wrap(s?.time) ?? { data: [] },
+    velocity_smooth: wrap(s?.velocity),
+    heartrate: wrap(s?.heartrate),
+    distance: wrap(s?.distance),
+    moving: wrap(s?.moving),
+  } as any;
+}
+
+function titleImpliesIntervals(title: string): boolean {
+  const t = title.toLowerCase();
+  if (/\b\d+\s*[x×]\s*\(?\d/.test(t)) return true; // 8x1000, 4x(3,2,1
+  if (/\d+\s*\/\s*\d+/.test(t)) return true; // 45/15
+  if (/\b(intervall|interval|tempo|terskel|threshold|sprint|bakke|hill|drag)\b/.test(t)) return true;
+  return false;
+}
+
+function repsInStructure(structure: any): number {
+  if (!Array.isArray(structure)) return 0;
+  let n = 0;
+  for (const set of structure) {
+    const stepReps = (set.steps ?? []).reduce((a: number, st: any) => a + (st.reps ?? 1), 0);
+    n += (set.set_reps ?? 1) * stepReps;
+  }
+  return n;
+}
+
+async function main() {
+  const files = readdirSync(DUMP)
+    .filter((f) => /^activity-\d+\.json$/.test(f))
+    .sort((a, b) => Number(a.match(/\d+/)![0]) - Number(b.match(/\d+/)![0]));
+
+  const flags: string[] = [];
+  let i = 0;
+  for (const f of files) {
+    const d = await Bun.file(`${DUMP}/${f}`).json();
+    const a = d.db.activity;
+    const laps = d.pipeline?.laps ?? [];
+    const time = d.pipeline?.streams?.time ?? [];
+    const streams = toStreamSet(d.pipeline?.streams);
+    const commit = a.trainingType ?? null;
+    const lapEvid = buildLapEvidenceBlock(laps, time);
+    const lapReps = lapEvid ? Number(lapEvid.match(/\*\*(\d+) work reps\*\*/)?.[1] ?? 0) : 0;
+
+    let got = "ERR";
+    let conf: number | string = "-";
+    let reps = 0;
+    let reason = "";
+    try {
+      const out = await invokeActivityAnalysisAgent(
+        streams,
+        a.title,
+        a.description || "-",
+        a.totalElevationGain ?? 0,
+        a.sportType,
+        null,
+        laps,
+      );
+      got = out?.training_type ?? "NULL";
+      conf = out?.confidence_score ?? "-";
+      reps = repsInStructure(out?.structure);
+      reason = String(out?.classification_reasoning ?? "").slice(0, 120);
+    } catch (e) {
+      reason = `EXC ${e instanceof Error ? e.message : String(e)}`;
+    }
+
+    const titleInt = titleImpliesIntervals(String(a.title || ""));
+    const gotInterval = INTERVAL_TYPES.has(got);
+    const marks: string[] = [];
+    if (commit && commit !== got) marks.push(`COMMIT≠ (${commit})`);
+    if (titleInt && got === "EASY") marks.push("TITLE-INT→EASY");
+    if (lapEvid && got === "EASY") marks.push(`LAPEVID(${lapReps})→EASY`);
+    if (lapEvid && gotInterval && reps > 0 && Math.abs(reps - lapReps) > 1)
+      marks.push(`REPΔ lap=${lapReps} struct=${reps}`);
+
+    const tag = marks.length ? `  ⚠️ ${marks.join(" ")}` : "";
+    if (marks.length) flags.push(`${a.id} "${String(a.title).slice(0, 26)}" → ${got}${tag}`);
+
+    console.log(
+      `${String(a.id).padStart(4)} ${(d.source?.kind || "-").padEnd(9)} laps=${String(laps.length).padStart(2)} lapEvid=${lapEvid ? lapReps : "-"} commit=${String(commit || "-").padEnd(15)} got=${String(got).padEnd(16)} conf=${conf} reps=${reps} "${String(a.title).slice(0, 26)}"${tag}`,
+    );
+    if (process.env.REASON) console.log(`       ${reason}`);
+    i++;
+    if (i < files.length) await sleep(DELAY_MS);
+  }
+
+  console.log(`\n===== FLAGS (${flags.length}) =====`);
+  for (const fl of flags) console.log(fl);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error("fatal:", e);
+    process.exit(1);
+  });

--- a/scripts/classify_check.ts
+++ b/scripts/classify_check.ts
@@ -63,6 +63,7 @@ async function main() {
       a.totalElevationGain ?? 0,
       a.sportType,
       null,
+      d.pipeline?.laps ?? [],
     );
     const got = out?.training_type ?? "NULL";
     const expected = EXPECTED[id] ?? "?";

--- a/src/agent/initial_analysis_agent.ts
+++ b/src/agent/initial_analysis_agent.ts
@@ -3,7 +3,9 @@ import { z } from "zod";
 import { trainingTypeEnum } from "../schema";
 import type { IntervalsIcuPrediction } from "../schema/activities";
 import { normalizeActivityStreams, prepareDataForLLM } from "../services/utils";
+import type { Lap } from "../types/strava/IDetailedActivity";
 import type { StreamSet } from "../types/strava/IStream";
+import { buildLapEvidenceBlock } from "./lap_evidence";
 import { gptMiniModel, invokeStructured } from "./model";
 import { venuePromptBlock } from "./running_venues";
 export type WorkoutAnalysisOutput = z.infer<typeof workoutAnalysisOutput>;
@@ -129,6 +131,44 @@ function formatIntervalsIcuBlock(prediction: IntervalsIcuPrediction | null | und
  * = 240s each; 240 < 120 -> SHORT"). A rep >= 120 s OR >= 800 m makes it LONG;
  * all reps shorter make it SHORT. Only touches the two interval subtypes.
  */
+/**
+ * Deterministic guardrail: collapse the Cartesian rep-count blowup. When the
+ * per-rep lap evidence lists N reps of slightly varying measured size, gpt-4o-mini
+ * sometimes emits N steps that EACH carry reps:N (observed: "10x1000m" → 9 steps ×
+ * reps 9 = 81; "Treadmill" → 14 × 14 = 196), inflating the rep count N→N². The
+ * signature is unmistakable and effectively never legitimate for N ≥ 3: a set whose
+ * steps are all the same work_type and all carry the SAME reps value R equal to the
+ * step count. Collapse it to a single step of reps:R sized at the MEDIAN measured
+ * value (median, not min/max, so a single under/over-measured rep can't flip the
+ * SHORT/LONG gate). Runs before reconcileIntervalSubtype so the gate sees the fixed
+ * structure. A genuine sequence ("3,2,1 km") has reps:1 per step and is untouched.
+ */
+export function reconcileStructureBlowup(
+  out: z.infer<typeof workoutAnalysisOutput>,
+): z.infer<typeof workoutAnalysisOutput> {
+  const structure = out.structure;
+  if (!structure || structure.length === 0) return out;
+  let changed = false;
+  const fixed = structure.map((set) => {
+    const steps = set.steps;
+    if (steps.length < 3) return set;
+    const r = steps[0].reps;
+    const isBlowup =
+      r === steps.length &&
+      steps.every((s) => s.reps === r && s.work_type === steps[0].work_type);
+    if (!isBlowup) return set;
+    const values = [...steps.map((s) => s.work_value)].sort((a, b) => a - b);
+    const mid = Math.floor(values.length / 2);
+    const median = values.length % 2 ? values[mid] : (values[mid - 1] + values[mid]) / 2;
+    changed = true;
+    return {
+      ...set,
+      steps: [{ ...steps[0], reps: r, work_value: Math.round(median) }],
+    };
+  });
+  return changed ? { ...out, structure: fixed } : out;
+}
+
 export function reconcileIntervalSubtype(
   out: z.infer<typeof workoutAnalysisOutput>,
 ): z.infer<typeof workoutAnalysisOutput> {
@@ -157,6 +197,7 @@ export async function invokeActivityAnalysisAgent(
   totalElevationGain: number,
   type: string,
   intervalsIcuPrediction?: IntervalsIcuPrediction | null,
+  laps: Lap[] = [],
   model: ChatOpenAI = gptMiniModel,
 ): Promise<WorkoutAnalysisOutput | null> {
   const normalized = normalizeActivityStreams(
@@ -180,12 +221,14 @@ export async function invokeActivityAnalysisAgent(
     )
     .join("\n");
   const intervalsIcuBlock = formatIntervalsIcuBlock(intervalsIcuPrediction);
+  const lapEvidenceBlock = buildLapEvidenceBlock(laps, streams?.time?.data ?? []);
   const prompt = `
   You are an expert running coach analyzing Strava activity data.
 
   ### 1. PRIORITY & CONTEXT
   - **Title/Description Priority:** You must prioritize the user's Title and Description over raw data IF the user explicitly names the workout (e.g., "10x400m", "Tempo Run", "Long Run").
   - **Ignore Generics:** If the title is generic (e.g., "Morning Run", "Lunch Run", "Run"), ignore it and rely 100% on the data stats.
+  - **Device Lap Evidence:** If a "DEVICE LAP EVIDENCE" block is present below, it is a deterministic work/rest split from the athlete's own lap markers (recoveries already removed by pace) and is the STRONGEST structural signal you have — stronger than the 30s-sampled table and stronger than a raw intervals.icu block (which often mislabels every lap WORK). When it shows a clean repeating work grid, classify as the matching interval type and take the per-rep size from it, even if the Title is ambiguous/non-English or the sampled table looks steady.
   - **Fartlek Warning:** Do not default to "Fartlek" just because the data is noisy. Fartlek requires distinct, intentional surges in pace that don't fit a fixed grid. If it's just a steady run with bad GPS data, classify as EASY.
 
   ### 2. CLASSIFICATION DEFINITIONS
@@ -206,7 +249,7 @@ export async function invokeActivityAnalysisAgent(
   **Sampled Data (30s Windows):**
   ${tableHeader}
   ${tableRows}
-${intervalsIcuBlock}
+${intervalsIcuBlock}${lapEvidenceBlock}
   ### 4. STRUCTURE EXTRACTION RULES (Hierarchical)
   You must populate the 'structure' array (an array of Sets) using these rules:
   
@@ -225,5 +268,5 @@ ${intervalsIcuBlock}
   First fill 'classification_reasoning': state the per-rep work duration (s) and/or distance (m) for ONE rep, then apply the SHORT vs LONG hard gate. Then classify the run and populate the structure according to the rules above.
 `;
   const result = await invokeStructured(workoutAnalysisOutput, prompt, "analyze activity", model);
-  return result ? reconcileIntervalSubtype(result) : result;
+  return result ? reconcileIntervalSubtype(reconcileStructureBlowup(result)) : result;
 }

--- a/src/agent/lap_evidence.ts
+++ b/src/agent/lap_evidence.ts
@@ -1,0 +1,94 @@
+import { classifyLaps, isJunkLap } from "../services/deterministic_segmenter";
+import type { Lap } from "../types/strava/IDetailedActivity";
+
+/**
+ * Deterministic lap-evidence hint for the classifier.
+ *
+ * The classifier otherwise sees only the title, a 30s-sampled stream table, and the
+ * intervals.icu prediction block. None of those reliably surface a clean rep grid:
+ * a colloquial title ("6x varme tusninger") can't be decoded into a per-rep size,
+ * the 30s sampling smears reps, and intervals.icu frequently labels EVERY manual lap
+ * `WORK` (recoveries included), so its block reads as noise. Yet the athlete's own
+ * lap markers usually encode the structure exactly — `classifyLaps` already isolates
+ * the fast WORK laps from warmup/cooldown/recovery by pace.
+ *
+ * This builds a small markdown block stating that deterministic work/rest split so
+ * the LLM can classify the interval session it would otherwise collapse to EASY.
+ * Returns "" unless the laps form a clear repeating grid (see the guards), so steady
+ * runs with per-km auto-laps don't get a fake structure.
+ */
+
+const MIN_WORK_REPS = 3;
+const MIN_WORK_REST_CONTRAST = 1.25;
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const s = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+function paceMinKm(speedMs: number): string {
+  if (speedMs <= 0) return "-";
+  const secPerKm = 1000 / speedMs;
+  const m = Math.floor(secPerKm / 60);
+  const s = Math.round(secPerKm % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function buildLapEvidenceBlock(laps: Lap[] | undefined, time: number[]): string {
+  if (!laps || laps.length === 0 || time.length === 0) return "";
+
+  const cls = classifyLaps(laps, time);
+  // Only the per-rep mode isolates individual reps; boundary/unusable can't.
+  if (cls.mode !== "per-rep") return "";
+
+  const work = cls.workLaps;
+  if (work.length < MIN_WORK_REPS) return "";
+
+  const meaningful = laps.filter((l) => !isJunkLap(l));
+  const workSet = new Set(work);
+  const nonWork = meaningful.filter((l) => !workSet.has(l));
+  // No warmup / recovery / cooldown laps at all → laps are uniform (e.g. steady run
+  // auto-lapped every km), not a work/rest grid. Don't invent a structure.
+  if (nonWork.length === 0) return "";
+
+  const workSpeed = median(work.map((l) => l.average_speed ?? 0));
+  const restSpeed = median(nonWork.map((l) => l.average_speed ?? 0));
+  // Work must be clearly faster than the rest of the laps, or it isn't an interval.
+  if (workSpeed <= 0 || restSpeed <= 0 || workSpeed < restSpeed * MIN_WORK_REST_CONTRAST) {
+    return "";
+  }
+
+  const firstWorkIdx = laps.indexOf(work[0]);
+  const lastWorkIdx = laps.indexOf(work[work.length - 1]);
+  const recoveries = laps
+    .filter((l, i) => i > firstWorkIdx && i < lastWorkIdx && !workSet.has(l) && !isJunkLap(l))
+    .map((l) => l.moving_time ?? l.elapsed_time ?? 0)
+    .filter((s) => s > 0);
+  const recoveryMed = recoveries.length ? Math.round(median(recoveries)) : null;
+
+  const rows = work
+    .map((l, i) => {
+      const dist = Math.round(l.distance ?? 0);
+      const dur = Math.round(l.moving_time ?? l.elapsed_time ?? 0);
+      const hr = l.average_heartrate != null ? `${Math.round(l.average_heartrate)}` : "-";
+      return `| ${i + 1} | ${dist} m | ${dur} s | ${paceMinKm(l.average_speed ?? 0)} | ${hr} |`;
+    })
+    .join("\n");
+
+  const recoveryLine =
+    recoveryMed != null ? ` Typical recovery between reps: ~${recoveryMed} s.` : "";
+  const contrast = (workSpeed / restSpeed).toFixed(1);
+
+  return `
+  ### DEVICE LAP EVIDENCE (deterministic work/rest split from the athlete's own lap markers — recoveries removed by pace)
+  The athlete's laps isolate **${work.length} work reps** (warmup, cooldown and recovery jogs excluded by pace):
+  | Rep | Distance | Duration | Pace (min/km) | Avg HR |
+  |-----|----------|----------|---------------|--------|
+${rows}
+ ${recoveryLine} Work pace is ~${contrast}× the recovery pace — a clear repeating structure.
+  Treat this as STRONG evidence of a deliberate interval session: classify as the matching interval type and size the SHORT vs LONG gate from the per-rep distance/duration above, even when the Title is ambiguous or non-English and the 30s table looks steady.
+  The ${work.length} rows above are the INDIVIDUAL reps; the session totals ${work.length} work reps. When they are one repeated effort (e.g. "${work.length}x1000m"), the structure is a single step with reps:${work.length} — not ${work.length} separate steps.
+`;
+}

--- a/src/agent/nodes/run_initial_agent.ts
+++ b/src/agent/nodes/run_initial_agent.ts
@@ -28,6 +28,7 @@ export async function runInitialAgent(
       state.totalElevationGain,
       state.activityType,
       state.intervalsIcuPrediction,
+      state.laps,
     ),
   );
 

--- a/src/services/deterministic_segmenter.ts
+++ b/src/services/deterministic_segmenter.ts
@@ -82,7 +82,7 @@ export function deriveSpeed(time: number[], distance: number[], windowSec = CFG.
   return v;
 }
 
-function isJunkLap(l: Lap): boolean {
+export function isJunkLap(l: Lap): boolean {
   const dur = l.elapsed_time ?? 0;
   const dist = l.distance ?? 0;
   const spd = l.average_speed ?? 0;

--- a/tests/structure_blowup_reconcile.test.ts
+++ b/tests/structure_blowup_reconcile.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import { reconcileStructureBlowup } from "../src/agent/initial_analysis_agent";
+
+// Pure guardrail: collapse the Cartesian rep-count blowup where gpt-4o-mini emits
+// N steps that EACH carry reps:N (observed: "10x1000m" -> 9 steps x reps 9 = 81),
+// inflating the count N->N². Collapse to a single step of reps:R at the median value.
+type Out = Parameters<typeof reconcileStructureBlowup>[0];
+const mk = (structure: unknown): Out =>
+  ({
+    classification_reasoning: "x",
+    training_type: "LONG_INTERVALS",
+    confidence_score: 0.9,
+    structure,
+  }) as Out;
+const blowup = (values: number[], work_type: "DISTANCE" | "TIME" = "DISTANCE") => [
+  {
+    set_reps: 1,
+    steps: values.map((v) => ({ reps: values.length, work_type, work_value: v })),
+  },
+];
+const totalReps = (out: Out): number =>
+  (out.structure ?? []).reduce(
+    (n, s) => n + (s.set_reps ?? 1) * s.steps.reduce((a, st) => a + (st.reps ?? 1), 0),
+    0,
+  );
+
+describe("reconcileStructureBlowup", () => {
+  it("collapses 9 steps x reps 9 (the 10x1000m N² blowup) to one step reps:9", () => {
+    const out = reconcileStructureBlowup(
+      mk(blowup([936, 906, 693, 954, 991, 959, 988, 1065, 1221])),
+    );
+    expect(totalReps(out)).toBe(9);
+    expect(out.structure![0].steps).toHaveLength(1);
+    expect(out.structure![0].steps[0].reps).toBe(9);
+  });
+  it("sizes the collapsed step at the MEDIAN so an under-measured rep can't flip the gate", () => {
+    // median of the set is ~959m (>=800 keeps LONG); the 693m min must not win.
+    const out = reconcileStructureBlowup(
+      mk(blowup([936, 906, 693, 954, 991, 959, 988, 1065, 1221])),
+    );
+    expect(out.structure![0].steps[0].work_value).toBeGreaterThanOrEqual(800);
+  });
+  it("collapses the 14x14 treadmill blowup to reps:14", () => {
+    const out = reconcileStructureBlowup(
+      mk(blowup([350, 330, 340, 414, 372, 351, 307, 410, 376, 421, 359, 427, 425, 415])),
+    );
+    expect(totalReps(out)).toBe(14);
+  });
+  it("leaves a genuine sequence (3,2,1 km, reps:1 per step) untouched", () => {
+    const seq = [
+      {
+        set_reps: 3,
+        steps: [
+          { reps: 1, work_type: "DISTANCE" as const, work_value: 3000 },
+          { reps: 1, work_type: "DISTANCE" as const, work_value: 2000 },
+          { reps: 1, work_type: "DISTANCE" as const, work_value: 1000 },
+        ],
+      },
+    ];
+    const out = reconcileStructureBlowup(mk(seq));
+    expect(out.structure).toEqual(seq);
+  });
+  it("leaves a clean single step (8x1000m) untouched", () => {
+    const s = [{ set_reps: 1, steps: [{ reps: 8, work_type: "DISTANCE" as const, work_value: 1000 }] }];
+    const out = reconcileStructureBlowup(mk(s));
+    expect(out.structure).toEqual(s);
+  });
+  it("does not collapse 2 steps x reps 2 (N<3 guard, avoids touching small ambiguous sets)", () => {
+    const s = blowup([400, 300]);
+    const out = reconcileStructureBlowup(mk(s));
+    expect(totalReps(out)).toBe(4);
+  });
+  it("does not collapse when reps != step count (3 steps but reps:1)", () => {
+    const s = [
+      {
+        set_reps: 1,
+        steps: [
+          { reps: 1, work_type: "DISTANCE" as const, work_value: 400 },
+          { reps: 1, work_type: "DISTANCE" as const, work_value: 400 },
+          { reps: 1, work_type: "DISTANCE" as const, work_value: 400 },
+        ],
+      },
+    ];
+    expect(reconcileStructureBlowup(mk(s)).structure).toEqual(s);
+  });
+  it("leaves output untouched when structure is missing", () => {
+    expect(reconcileStructureBlowup(mk(null)).structure).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

The session classifier only saw the activity **title**, a **30s-sampled stream table**, and the **intervals.icu prediction block**. None reliably surfaces a rep grid, so clear interval sessions collapsed to **EASY**:

- a colloquial title (`6x varme tusninger`) can't be decoded into a per-rep size,
- 30s sampling smears reps into a steady-looking table,
- intervals.icu frequently labels **every** manual lap `WORK` (recoveries included), so its block reads as noise.

Trigger case: activity 1293, a textbook **6×1000m**, classified EASY (conf 0.85). The cleanest signal — the athlete's own lap markers — never reached the classifier; lap analysis sat *downstream* of, and gated behind, the LLM verdict.

## Fix

- **`src/agent/lap_evidence.ts`** — `buildLapEvidenceBlock` re-derives a deterministic work/rest split from the laps via `classifyLaps` (per-rep mode) and injects it into the prompt as the strongest structural signal. Guards against steady per-km auto-laps producing a fake structure: per-rep mode only, ≥3 work reps, non-work laps must exist, work pace ≥1.25× recovery pace.
- **`invokeActivityAnalysisAgent`** gains a `laps` param (wired from `state.laps` in `run_initial_agent.ts`); the prompt's PRIORITY section ranks the block above the 30s table and the raw icu block.
- **`reconcileStructureBlowup`** — deterministic post-LLM guardrail that collapses the Cartesian rep-count blowup (lap enumeration made gpt-4o-mini emit N steps each `reps:N`, e.g. `10x1000m` → 81 reps) to one step `reps:N` at the **median** value (so an under/over-measured rep can't flip the SHORT/LONG gate). Runs before `reconcileIntervalSubtype`; genuine sequences (`3,2,1 km`) are untouched.
- **`scripts/audit_classify.ts`** — full-corpus classifier audit harness; `classify_check.ts` / `ab_model.ts` pass dump laps.
- **`tests/structure_blowup_reconcile.test.ts`** — 8 cases.

## Verification

- Activity 1293: EASY → **LONG_INTERVALS** (conf 0.95), reasoning reads the 6×~1000m off the laps.
- Generic-title sessions (`Oslo Running`, `Treadmill Running`) that were previously type-less are now correctly recovered as intervals; genuine easy runs stay EASY.
- Structure blowups fixed (626: 81→9 reps, 389: 196→14 reps) with no regression to legit sequences.
- Golden `classify_check` **14/14**; full suite **377 pass / 0 fail**; `tsc` clean.

## Notes

- Pure dev-harness scripts use the existing `toStreamSet(...) as any` convention; production code has no `any`.
- A residual loophole (single-rep efforts labelled an interval type, e.g. fixtures 137/138) is **not** auto-fixed here — demoting on `reps≤1` is unsafe because an empty structure can also mean extraction failure on a real interval. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
