### PR TITLE
fix(dashboard): training-summary today uses athlete-local date

### DIFF
--- a/src/controllers/dashboard_controller.ts
+++ b/src/controllers/dashboard_controller.ts
@@ -203,10 +203,15 @@ export async function getTrainingSummary(
   db: Db,
   userId: string,
   clerkUserId: string,
+  localDate?: string,
 ): Promise<z.infer<typeof TrainingSummaryResponseSchema>> {
+  // `activitiesOnDate` matches against `startDateLocal`, so "today" must be the
+  // athlete's local calendar date. Fall back to the server's UTC date only when
+  // the client doesn't supply one.
+  const today = localDate ?? toISODate(new Date());
   const [summary, todayRows] = await Promise.all([
     fetchTrainingSummary(clerkUserId),
-    dashboardRepo.activitiesOnDate(db, userId, toISODate(new Date())),
+    dashboardRepo.activitiesOnDate(db, userId, today),
   ]);
   if (summary.status !== "ok") return summary;
 

--- a/src/routers/dashboard_router.ts
+++ b/src/routers/dashboard_router.ts
@@ -10,6 +10,7 @@ import {
   FitnessSeriesResponseSchema,
   PaceAnchorQuerySchema,
   PaceAnchorResponseSchema,
+  TrainingSummaryQuerySchema,
   TrainingSummaryResponseSchema,
   WeekDetailResponseSchema,
   WellnessQuerySchema,
@@ -49,7 +50,7 @@ dashboardRouter.get(
   "/training-summary",
   describeRoute({
     description:
-      "Current intervals.icu training-summary snapshot. Always returns an object discriminated by `status`: `ok` (data populated with latest wellness record — fitness model, sleep, recovery, body), `not_linked` (intervals.icu not connected), or `no_recent_data` (linked, but no wellness records in the past 7 days). All metrics in `data` are auto/device-sourced (no subjective fields).",
+      "Current intervals.icu training-summary snapshot. Always returns an object discriminated by `status`: `ok` (data populated with latest wellness record — fitness model, sleep, recovery, body), `not_linked` (intervals.icu not connected), or `no_recent_data` (linked, but no wellness records in the past 7 days). All metrics in `data` are auto/device-sourced (no subjective fields). Pass `date` (YYYY-MM-DD, the athlete's local calendar date) so `trainedToday`/`todaySessions` are resolved against the athlete's day rather than the server's UTC day.",
     responses: {
       200: {
         description: "Discriminated training-summary result",
@@ -57,11 +58,14 @@ dashboardRouter.get(
       },
     },
   }),
+  validator("query", TrainingSummaryQuerySchema),
   async (c) => {
+    const { date } = c.req.valid("query");
     const summary = await dashboardController.getTrainingSummary(
       c.env.db,
       c.get("userId"),
       c.get("clerkUserId"),
+      date,
     );
     return c.json(summary);
   },

--- a/src/schemas/api_schemas.ts
+++ b/src/schemas/api_schemas.ts
@@ -606,6 +606,10 @@ export const WellnessQuerySchema = z
     },
   );
 
+export const TrainingSummaryQuerySchema = z.object({
+  date: isoDate.optional(),
+});
+
 const MetricStatsSchema = z
   .object({
     latest: z.number().nullable(),


### PR DESCRIPTION
## Summary

Resolve the training-summary "today" against the **athlete's local calendar date** instead of the server's UTC date.

`getTrainingSummary` computed "today" via `toISODate(new Date())` (server UTC) while `dashboardRepo.activitiesOnDate` matches on `startDateLocal`. For UTC+ athletes, a run could show as "trained today" during the local 00:00–02:00 window (server still on the previous date), or the reverse.

### Changes
- `GET /dashboard/training-summary` accepts an optional `date` query param (`YYYY-MM-DD`, athlete-local) validated by the new `TrainingSummaryQuerySchema`.
- `getTrainingSummary(db, userId, clerkUserId, localDate?)` uses `localDate ?? toISODate(new Date())` so `trainedToday` / `todaySessions` resolve against the athlete's day, falling back to server UTC when the client doesn't send one.
- OpenAPI description updated to document the param.

Pairs with the app PR (`update-profil` on IntervalInsights-app), which sends the local date.

## Testing
- `npx tsc --noEmit` — no new `src/` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
