### PR TITLE
feat(scripts): add scripts:status to show pending migrations + run-once scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ bun run build        # Compile to single binary (./server)
 
 bun run db:generate  # Generate Drizzle migrations from schema changes
 bun run db:migrate   # Run pending migrations
+bun run scripts:status  # Show applied/pending state: Drizzle migrations + run-once scripts (exits 1 if pending)
+bun run scripts:run     # Run all pending run-once scripts (see scripts/README.md)
 bun run db:push      # Push schema directly (dev only)
 bun run db:studio    # Open Drizzle Studio UI
 ```

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "scripts:run": "bun run scripts/run_pending.ts",
+    "scripts:status": "bun run scripts/status.ts",
     "brain:sync": "rm -rf knowledge/brain && mkdir -p knowledge && cp -R ../interval-brain/brain knowledge/brain && rm -rf knowledge/brain/_templates && rm -f knowledge/brain/log.md"
   },
   "dependencies": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,6 +26,17 @@ runScript({ name: "my_script", once: false, db, pool }, main);
   logs and exits 0 without running again. Use for one-time data backfills.
 - On failure the body should `throw` (the harness records `status = 'failed'` and exits 1).
 
+### Checking what's pending on the current DB
+
+```bash
+bun run scripts:status     # == bun run scripts/status.ts
+```
+
+Read-only status against `DATABASE_URL`: lists every Drizzle migration
+(journal vs `drizzle.__drizzle_migrations`) and every run-once script
+(registry vs `script_runs`) with applied/pending state. Exits 1 when anything
+is pending, so it can gate other commands.
+
 ### Running all pending run-once scripts
 
 ```bash
@@ -35,8 +46,9 @@ bun run scripts:run        # == bun run scripts/run_pending.ts
 Migration-style runner: checks `script_runs`, then runs only the run-once scripts that
 haven't completed yet (in order, clerk sync last), streaming each script's output and
 stopping on the first failure. Already-completed scripts are skipped. The ordered registry
-lives in `scripts/run_pending.ts` — keep it in sync with the `once: true` scripts. This is a
-manual command; it is **not** wired into deploy (deploy runs only `db:migrate`).
+lives in `scripts/_registry.ts` (shared with `status.ts`) — keep it in sync with the
+`once: true` scripts. This is a manual command; it is **not** wired into deploy
+(deploy runs only `db:migrate`).
 
 ### Baselining already-run scripts
 

--- a/scripts/_registry.ts
+++ b/scripts/_registry.ts
@@ -1,0 +1,9 @@
+// Ordered registry of run-once scripts. Keep in sync with the `once: true`
+// scripts in this directory; clerk sync runs last.
+export const ONCE_SCRIPTS = [
+  "backfill_events",
+  "backfill_gears",
+  "backfill_hr_stats",
+  "run_backfill_fold",
+  "sync_clerk_to_db",
+] as const;

--- a/scripts/run_pending.ts
+++ b/scripts/run_pending.ts
@@ -3,16 +3,7 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "../src/schema";
 import { scriptRuns } from "../src/schema";
-
-// Ordered registry of run-once scripts. Keep in sync with the `once: true`
-// scripts in this directory; clerk sync runs last.
-const ONCE_SCRIPTS = [
-  "backfill_events",
-  "backfill_gears",
-  "backfill_hr_stats",
-  "run_backfill_fold",
-  "sync_clerk_to_db",
-] as const;
+import { ONCE_SCRIPTS } from "./_registry";
 
 if (!process.env.DATABASE_URL) {
   console.error("DATABASE_URL is required");

--- a/scripts/status.ts
+++ b/scripts/status.ts
@@ -1,0 +1,97 @@
+import { and, desc, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import * as schema from "../src/schema";
+import { scriptRuns } from "../src/schema";
+import { ONCE_SCRIPTS } from "./_registry";
+
+interface JournalEntry {
+  idx: number;
+  when: number;
+  tag: string;
+}
+
+if (!process.env.DATABASE_URL) {
+  console.error("DATABASE_URL is required");
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const db = drizzle({ client: pool, schema });
+
+async function lastAppliedMigrationMillis(): Promise<number> {
+  try {
+    const res = await pool.query<{ created_at: string }>(
+      "SELECT created_at FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 1",
+    );
+    return res.rows[0] ? Number(res.rows[0].created_at) : 0;
+  } catch (err) {
+    if ((err as { code?: string }).code === "42P01") return 0; // fresh DB, table not created yet
+    throw err;
+  }
+}
+
+async function migrationStatus(): Promise<number> {
+  const journal = (await Bun.file(new URL("../drizzle/meta/_journal.json", import.meta.url)).json()) as {
+    entries: JournalEntry[];
+  };
+  // Mirrors drizzle's migrator: an entry is pending when its journal
+  // timestamp is newer than the last row in drizzle.__drizzle_migrations.
+  const lastApplied = await lastAppliedMigrationMillis();
+
+  console.log("── Drizzle migrations (drizzle/) ──");
+  let pending = 0;
+  for (const entry of journal.entries) {
+    if (entry.when > lastApplied) {
+      pending++;
+      console.log(`  ✗ ${entry.tag} — PENDING`);
+    } else {
+      console.log(`  ✓ ${entry.tag}`);
+    }
+  }
+  const applied = journal.entries.length - pending;
+  console.log(
+    pending === 0
+      ? `  ${applied} applied, none pending.`
+      : `  ${applied} applied, ${pending} pending → bun run db:migrate`,
+  );
+  return pending;
+}
+
+async function scriptStatus(): Promise<number> {
+  console.log("\n── Run-once scripts (scripts/) ──");
+  let pending = 0;
+  for (const name of ONCE_SCRIPTS) {
+    const [done] = await db
+      .select({ finishedAt: scriptRuns.finishedAt })
+      .from(scriptRuns)
+      .where(and(eq(scriptRuns.name, name), eq(scriptRuns.status, "completed")))
+      .orderBy(desc(scriptRuns.finishedAt))
+      .limit(1);
+    if (done) {
+      console.log(`  ✓ ${name} — completed ${done.finishedAt?.toISOString().slice(0, 10) ?? "(baseline)"}`);
+    } else {
+      pending++;
+      console.log(`  ✗ ${name} — PENDING`);
+    }
+  }
+  console.log(
+    pending === 0
+      ? `  ${ONCE_SCRIPTS.length} completed, none pending.`
+      : `  ${ONCE_SCRIPTS.length - pending} completed, ${pending} pending → bun run scripts:run`,
+  );
+  return pending;
+}
+
+async function main() {
+  const pendingMigrations = await migrationStatus();
+  const pendingScripts = await scriptStatus();
+  await pool.end();
+  process.exit(pendingMigrations + pendingScripts > 0 ? 1 : 0);
+}
+
+main().catch(async (err) => {
+  console.error("[status] fatal:", err);
+  await pool.end().catch(() => {});
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- New `bun run scripts:status` (`scripts/status.ts`): read-only status against `DATABASE_URL` showing every Drizzle migration (journal vs `drizzle.__drizzle_migrations`, same newer-than-last-applied logic as the Drizzle migrator) and every run-once script (registry vs `script_runs`) with applied/pending state
- Exits 1 when anything is pending, so it can gate other commands; points at `bun run db:migrate` / `bun run scripts:run` when there is work to do
- Extracted the ordered run-once registry to `scripts/_registry.ts`, shared by `status.ts` and `run_pending.ts`
- Documented the command in `scripts/README.md` and `CLAUDE.md`

## Test plan
- [x] `bun run scripts:status` against the local dev DB: 29 migrations applied, 5 run-once scripts pending, exit 1
- [x] `bun run scripts:run` executed all 5 pending scripts locally (exit 0), after which `scripts:status` reports everything completed and exits 0
- [x] `run_pending.ts` parse-checked after the registry extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)