### PR TITLE
feat(oauth): trampoline pages for /strava-callback + /intervals-callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import suggestSessionRouter from "./routers/suggest_session_router";
 import trainingRouter from "./routers/training_router";
 import userRouter from "./routers/user_router";
 import type { TGlobalEnv } from "./types/IRouters";
+import { registerOAuthCallbackPages } from "./web/oauth_callback_page";
 import { registerWebPages } from "./web/pages";
 
 const app = new Hono<TGlobalEnv>();
@@ -88,6 +89,7 @@ app.get("/.well-known/assetlinks.json", async (_c) => {
 });
 
 registerWebPages(app);
+registerOAuthCallbackPages(app);
 
 app.use("*", requestId());
 app.use(

--- a/src/web/oauth_callback_page.ts
+++ b/src/web/oauth_callback_page.ts
@@ -1,0 +1,138 @@
+import type { Env, Hono } from "hono";
+import { config } from "../config";
+
+const ANDROID_PACKAGE = "no.cvebbesen.intervalinsights";
+const PLAY_STORE_URL = `https://play.google.com/store/apps/details?id=${ANDROID_PACKAGE}`;
+// Only these OAuth params are forwarded to the app; anything else in the query is dropped.
+const FORWARDED_PARAMS = ["code", "error", "state", "scope"] as const;
+
+const STYLES = `
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: #F1F5F9;
+    color: #334155;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    display: flex;
+    min-height: 100vh;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+  }
+  main {
+    max-width: 420px;
+    width: 100%;
+    background: #fff;
+    border: 1px solid #CBD5E1;
+    border-radius: 16px;
+    padding: 2.5rem 2rem;
+    box-shadow: 0 4px 24px rgba(15, 10, 81, 0.05);
+    text-align: center;
+  }
+  img.icon { width: 64px; height: 64px; object-fit: contain; margin-bottom: 1rem; }
+  h1 {
+    font-size: 1.4rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: #0F0A51;
+    margin-bottom: 0.75rem;
+  }
+  p { margin: 0.5rem 0 1.5rem; color: #475569; }
+  a.button {
+    display: inline-block;
+    background: #448AFF;
+    color: #fff;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.85rem 2rem;
+    border-radius: 999px;
+  }
+  a.button:hover { background: #2F6FE0; }
+  p.hint { margin: 1.25rem 0 0; font-size: 0.85rem; color: #94A3B8; }
+  p.hint a { color: #64748B; }
+`;
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function trampolinePage(
+  provider: string,
+  appLinkUrl: string,
+  intentUrl: string,
+  denied: boolean,
+): string {
+  const title = denied ? `${provider} connection cancelled` : `${provider} connected`;
+  const lead = denied
+    ? `The ${provider} authorization was not completed. Return to the app to try again.`
+    : `Almost done — return to the app to finish connecting ${provider}.`;
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${escapeHtml(title)} · Interval Insights</title>
+  <link rel="icon" type="image/png" href="/favicon.ico" />
+  <style>${STYLES}</style>
+</head>
+<body>
+  <main>
+    <img class="icon" src="/app-icon.png" alt="Interval Insights icon" />
+    <h1>${escapeHtml(title)}</h1>
+    <p>${escapeHtml(lead)}</p>
+    <a id="open-app" class="button" href="${escapeHtml(appLinkUrl)}">Open Interval Insights</a>
+    <p class="hint">
+      Nothing happening? Get the app on
+      <a href="${escapeHtml(PLAY_STORE_URL)}">Google Play</a>.
+    </p>
+  </main>
+  <script>
+    (function () {
+      if (/android/i.test(navigator.userAgent)) {
+        document.getElementById("open-app").setAttribute("href", ${JSON.stringify(intentUrl)});
+      }
+    })();
+  </script>
+</body>
+</html>`;
+}
+
+/**
+ * OAuth callback "trampoline" pages at the universal-link paths. The OS is
+ * supposed to intercept these URLs before any request is made, but browsers
+ * keep non-gesture redirects in the tab (intervals.icu always; Strava when its
+ * app isn't installed). This page hands the flow back to the app via a
+ * gesture-driven tap — an Android intent:// link (with a Play Store fallback)
+ * or the plain universal link elsewhere. Mounted in src/index.ts and the test app.
+ */
+export function registerOAuthCallbackPages<E extends Env>(app: Hono<E>): void {
+  const callbacks = [
+    { path: "/strava-callback", provider: "Strava" },
+    { path: "/intervals-callback", provider: "intervals.icu" },
+  ] as const;
+
+  for (const { path, provider } of callbacks) {
+    app.get(path, (c) => {
+      const params = new URLSearchParams();
+      for (const key of FORWARDED_PARAMS) {
+        const value = c.req.query(key);
+        if (value !== undefined) params.set(key, value);
+      }
+      const appLink = new URL(path, config.APP_BASE_URL);
+      appLink.search = params.toString();
+      const intentUrl = `intent://${appLink.host}${path}${appLink.search}#Intent;scheme=https;package=${ANDROID_PACKAGE};S.browser_fallback_url=${encodeURIComponent(PLAY_STORE_URL)};end`;
+      const html = trampolinePage(provider, appLink.toString(), intentUrl, params.has("error"));
+      return new Response(html, {
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "no-store",
+        },
+      });
+    });
+  }
+}

--- a/tests/helpers/test_app.ts
+++ b/tests/helpers/test_app.ts
@@ -36,6 +36,7 @@ import suggestSessionRouter from "../../src/routers/suggest_session_router";
 import userRouter from "../../src/routers/user_router";
 import * as schema from "../../src/schema";
 import type { TGlobalEnv } from "../../src/types/IRouters";
+import { registerOAuthCallbackPages } from "../../src/web/oauth_callback_page";
 import { registerWebPages } from "../../src/web/pages";
 
 export type TestIdentity = {
@@ -86,6 +87,7 @@ export function buildTestApp(pool: Pool) {
   app.use("*", testLoggerMiddleware);
 
   registerWebPages(app);
+registerOAuthCallbackPages(app);
 
   app.route("/api", publicRouter);
 

--- a/tests/public.test.ts
+++ b/tests/public.test.ts
@@ -149,6 +149,38 @@ describe("public web pages (rendered HTML)", () => {
   });
 });
 
+describe("oauth callback trampoline pages", () => {
+  it("GET /strava-callback serves the trampoline with the code forwarded via intent://", async () => {
+    const res = await app.fetch(new Request("http://test/strava-callback?code=abc123"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = await res.text();
+    expect(body).toContain("Open Interval Insights");
+    expect(body).toContain("intent://");
+    expect(body).toContain("package=no.cvebbesen.intervalinsights");
+    expect(body).toContain("code=abc123");
+  });
+
+  it("GET /intervals-callback forwards a provider error and renders the cancelled copy", async () => {
+    const res = await app.fetch(new Request("http://test/intervals-callback?error=access_denied"));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("cancelled");
+    expect(body).toContain("error=access_denied");
+  });
+
+  it("drops unknown query params and neutralizes HTML in forwarded values", async () => {
+    const res = await app.fetch(
+      new Request('http://test/strava-callback?code=x"><script>alert(1)</script>&evil=1'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).not.toContain("<script>alert(1)</script>");
+    expect(body).not.toContain("evil=1");
+  });
+});
+
 describe("auth gate", () => {
   it("authenticated routes refuse to run without a test identity", async () => {
     // No withIdentity() wrapper → testAuthGuard returns 401.


### PR DESCRIPTION
## Problem

OAuth callbacks rely entirely on the OS intercepting the universal-link URL — the backend had no handler at `/strava-callback` or `/intervals-callback`, so any browser that actually loaded the URL got the JSON 404.

Browsers keep non-gesture in-tab redirects in the browser regardless of App Links verification. intervals.icu's accept step always ends in such a redirect, so connecting intervals.icu dead-ended on `{"error":"Not Found"}` with the auth code stranded in the URL. Strava has the same latent dead end for users without the Strava app (with it installed, Strava fires the callback as a fresh intent, which always works).

## Fix

Serve a minimal trampoline page at both callback paths (`src/web/oauth_callback_page.ts`):

- "Open Interval Insights" button; on Android it's swapped to an `intent://` link carrying the code — an explicit, gesture-driven handoff Chrome always honors, working even when App Links verification is broken. Play Store fallback via `S.browser_fallback_url` when the app isn't installed.
- Provider-denied case (`error=access_denied`) renders cancelled copy and forwards the error so the app's callback screen handles it.
- Only `code`/`error`/`state`/`scope` are forwarded; values HTML-escaped; `Cache-Control: no-store` (URL carries an auth code).
- The OS-interception happy path is untouched — the page only appears where users previously hit the 404.

## Tests

Three new endpoint tests in `tests/public.test.ts` (trampoline render + intent URL, error forwarding, XSS/param-whitelist probe). `bun run check` green: 524 pass, tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)