### PR TITLE
HR backfill on consent enable + intervals.icu consent-gate fix

### DIFF
--- a/src/repositories/activity_repository.ts
+++ b/src/repositories/activity_repository.ts
@@ -8,6 +8,7 @@ import {
   ilike,
   inArray,
   isNotNull,
+  isNull,
   lte,
   or,
   type SQL,
@@ -216,6 +217,61 @@ export async function listForHrAnalysis(
     .select(hrAnalysisColumns)
     .from(activities)
     .where(and(...filters))
+    .orderBy(desc(activities.startDateLocal));
+}
+
+/**
+ * Repair intervals.icu-sourced rows that stored an average HR but never set the
+ * `hasHeartrate` flag. Purely local — no external API. Returns the row count.
+ */
+export async function repairHasHeartrateFlag(db: Db, userId: string): Promise<number> {
+  const rows = await db
+    .update(activities)
+    .set({ hasHeartrate: true })
+    .where(
+      and(
+        eq(activities.userId, userId),
+        eq(activities.hasHeartrate, false),
+        isNotNull(activities.averageHeartRate),
+      ),
+    )
+    .returning({ id: activities.id });
+  return rows.length;
+}
+
+/**
+ * Write summary HR (avg/max + flag) onto an activity and clear
+ * `hrStatsComputedAt` so Phase B recomputes its stream-derived stats.
+ */
+export async function updateSummaryHr(
+  db: Db,
+  activityId: number,
+  hr: { averageHeartRate: number | null; maxHeartRate: number | null; hasHeartrate: boolean },
+): Promise<void> {
+  await db
+    .update(activities)
+    .set({
+      averageHeartRate: hr.averageHeartRate,
+      maxHeartRate: hr.maxHeartRate,
+      hasHeartrate: hr.hasHeartrate,
+      hrStatsComputedAt: null,
+    })
+    .where(eq(activities.id, activityId));
+}
+
+/** Completed HR-bearing activities whose stream stats have never been computed. */
+export function listHrStatsBackfillCandidates(db: Db, userId: string): Promise<HrAnalysisRow[]> {
+  return db
+    .select(hrAnalysisColumns)
+    .from(activities)
+    .where(
+      and(
+        eq(activities.userId, userId),
+        eq(activities.analysisStatus, "completed"),
+        isNull(activities.hrStatsComputedAt),
+        eq(activities.hasHeartrate, true),
+      ),
+    )
     .orderBy(desc(activities.startDateLocal));
 }
 

--- a/src/routers/heart_rate_router.ts
+++ b/src/routers/heart_rate_router.ts
@@ -1,11 +1,16 @@
 import { Hono } from "hono";
 import { describeRoute, resolver, validator } from "hono-openapi";
+import { runInBackground } from "../background";
+import { AppError } from "../error";
+import { SyncStartedSchema } from "../schemas/activity_schemas";
 import {
   ErrorSchema,
   HeartRateAnalysisRequestSchema,
   HeartRateAnalysisResponseSchema,
 } from "../schemas/api_schemas";
 import { getHeartRateAnalysis } from "../services/heart_rate_analysis_service";
+import { userHasHeartRateConsent } from "../services/heart_rate_consent_service";
+import { isHrBackfillRunning, runHrBackfill } from "../services/hr_backfill_service";
 import type { TGlobalEnv } from "../types/IRouters";
 
 const heartRateRouter = new Hono<TGlobalEnv>();
@@ -37,6 +42,39 @@ heartRateRouter.post(
       c.var.logger,
     );
     return c.json(result);
+  },
+);
+
+heartRateRouter.post(
+  "/backfill",
+  describeRoute({
+    description:
+      "Start a background heart-rate backfill for the authenticated user: repairs the hasHeartrate flag on intervals.icu-sourced rows, re-fetches lost Strava HR summaries, and computes missing HR stream stats. Requires heart-rate processing consent. Fire-and-forget: returns 202 immediately and reports progress over the SSE progress channel as sync events with kind 'hr_backfill' (started -> progress {done,total} every 25 rows -> completed, one of hr_backfill_completed{computed} / _more{computed,remaining} / _rate_limited(+retryAt) / _up_to_date). 403 if consent is off; 409 if a backfill is already running for this user.",
+    responses: {
+      202: {
+        description: "Backfill started",
+        content: { "application/json": { schema: resolver(SyncStartedSchema) } },
+      },
+      403: {
+        description: "Heart-rate processing not enabled",
+        content: { "application/json": { schema: resolver(ErrorSchema) } },
+      },
+      409: {
+        description: "A backfill is already running",
+        content: { "application/json": { schema: resolver(ErrorSchema) } },
+      },
+    },
+  }),
+  async (c) => {
+    const userId = c.get("userId");
+    if (!(await userHasHeartRateConsent(c.env.db, userId)))
+      throw new AppError(403, "Heart-rate processing not enabled for this account");
+    if (isHrBackfillRunning(userId))
+      throw new AppError(409, "A heart-rate backfill is already running");
+    runInBackground("heartRate.backfill", () => runHrBackfill(c.env, userId, c.var.logger), {
+      logger: c.var.logger,
+    });
+    return c.json({ status: "started" as const }, 202);
   },
 );
 

--- a/src/services/heart_rate_analysis_service.ts
+++ b/src/services/heart_rate_analysis_service.ts
@@ -178,11 +178,11 @@ async function fillMissingStats(
  * no usable source exists.
  */
 async function resolveStreams(
-  intervalsToken: string,
+  intervalsToken: string | null,
   stravaToken: string | null,
   row: HrAnalysisRow,
 ): Promise<Pick<StreamSet, "time" | "heartrate"> | null> {
-  if (row.intervalsIcuId) {
+  if (intervalsToken && row.intervalsIcuId) {
     try {
       const normalized = normalizeIntervalsStreams(
         await intervalsApiService.getActivityStreams(intervalsToken, row.intervalsIcuId, [
@@ -215,9 +215,9 @@ export function normalizeIntervalsStreams(raw: unknown): Pick<StreamSet, "time" 
  * fallback), compute whole-activity and work-interval stats, persist them, and
  * mutate `row` in place so the response reflects the freshly computed values.
  */
-async function computeAndPersistRow(
+export async function computeAndPersistRow(
   db: Db,
-  intervalsToken: string,
+  intervalsToken: string | null,
   stravaToken: string | null,
   row: HrAnalysisRow,
 ): Promise<void> {

--- a/src/services/hr_backfill_service.ts
+++ b/src/services/hr_backfill_service.ts
@@ -1,0 +1,198 @@
+import { sleep } from "bun";
+import { and, eq, isNull } from "drizzle-orm";
+import { StravaError } from "../error";
+import type { Logger } from "../logger";
+import { getIntervalsAccessToken } from "../middlewares/intervals_middleware";
+import { getStravaAccessTokens } from "../middlewares/strava_middleware";
+import * as activityRepo from "../repositories/activity_repository";
+import { activities } from "../schema";
+import type { IGlobalBindings } from "../types/IRouters";
+import type { SummaryActivity } from "../types/strava/IDetailedActivity";
+import { computeAndPersistRow } from "./heart_rate_analysis_service";
+import { publishSync } from "./progress_service";
+import { type StravaRateLimit, stravaApiService } from "./strava_api_service";
+import { nextStravaWindowMs, overBudget } from "./strava_link_service";
+
+const SYNC_KIND = "hr_backfill";
+const SYNC_TITLE = "Heart rate";
+const PAGE_SIZE = 200;
+const MAX_LIST_PAGES = 20;
+const MAX_STREAM_FETCHES_PER_RUN = 300;
+const STREAM_THROTTLE_MS = 1000;
+const LIST_THROTTLE_MS = 200;
+const PROGRESS_EVERY = 25;
+
+export interface HrBackfillResult {
+  summaryUpdated: number;
+  statsComputed: number;
+  remaining: number;
+  failed: number;
+  retryAt?: number;
+}
+
+const activeBackfills = new Set<string>();
+
+export function isHrBackfillRunning(userId: string): boolean {
+  return activeBackfills.has(userId);
+}
+
+function hrBackfillCompletedMessage(
+  r: HrBackfillResult,
+  retryAt?: number,
+): { messageKey: string; messageArgs: Record<string, string> } {
+  if (retryAt) return { messageKey: "hr_backfill_completed_rate_limited", messageArgs: {} };
+  if (r.remaining > 0) {
+    return {
+      messageKey: "hr_backfill_completed_more",
+      messageArgs: { computed: String(r.statsComputed), remaining: String(r.remaining) },
+    };
+  }
+  if (r.summaryUpdated + r.statsComputed === 0) {
+    return { messageKey: "hr_backfill_completed_up_to_date", messageArgs: {} };
+  }
+  return {
+    messageKey: "hr_backfill_completed",
+    messageArgs: { computed: String(r.statsComputed) },
+  };
+}
+
+/**
+ * Backfill missing heart-rate data for a user in three phases: (A1) repair the
+ * `hasHeartrate` flag on intervals.icu-sourced rows, (A2) re-fetch lost Strava
+ * HR summaries, (B) compute missing HR stream stats. Emits SSE sync events and
+ * always finishes with a `completed` event, even on crash. Resumable and
+ * rate-limit aware — Phase B converges because `computeAndPersistRow` always
+ * stamps `hrStatsComputedAt`.
+ */
+export async function runHrBackfill(
+  context: IGlobalBindings,
+  userId: string,
+  log: Logger,
+): Promise<HrBackfillResult> {
+  const result: HrBackfillResult = { summaryUpdated: 0, statsComputed: 0, remaining: 0, failed: 0 };
+  let retryAt: number | undefined;
+
+  activeBackfills.add(userId);
+  await publishSync(userId, { kind: SYNC_KIND, phase: "started", title: SYNC_TITLE });
+
+  try {
+    let stravaToken: string | null = null;
+    try {
+      stravaToken = (await getStravaAccessTokens(userId)).access_token;
+    } catch (err) {
+      log.warn({ err }, "no Strava token for HR backfill");
+    }
+
+    let intervalsToken: string | null = null;
+    try {
+      intervalsToken = await getIntervalsAccessToken(userId);
+    } catch (err) {
+      log.warn({ err }, "no intervals.icu token for HR backfill");
+    }
+
+    // Phase A1: repair intervals.icu-sourced rows that stored HR but never set the flag.
+    result.summaryUpdated += await activityRepo.repairHasHeartrateFlag(context.db, userId);
+
+    // Phase A2: re-fetch lost Strava HR summaries for rows still missing avg HR.
+    if (stravaToken) {
+      const localRows = await context.db
+        .select({
+          id: activities.id,
+          stravaActivityId: activities.stravaActivityId,
+          intervalsStravaId: activities.intervalsStravaId,
+        })
+        .from(activities)
+        .where(and(eq(activities.userId, userId), isNull(activities.averageHeartRate)));
+
+      const byStravaId = new Map<number, { id: number }>();
+      for (const row of localRows) {
+        if (row.stravaActivityId != null) byStravaId.set(row.stravaActivityId, { id: row.id });
+        if (row.intervalsStravaId != null) byStravaId.set(row.intervalsStravaId, { id: row.id });
+      }
+
+      let lastRateLimit: StravaRateLimit | null = null;
+      for (let page = 1; page <= MAX_LIST_PAGES; page++) {
+        let summaries: SummaryActivity[];
+        try {
+          const res = await stravaApiService.listAthleteActivitiesWithMeta(stravaToken, {
+            per_page: String(PAGE_SIZE),
+            page: String(page),
+          });
+          summaries = res.data;
+          lastRateLimit = res.rateLimit;
+        } catch (err) {
+          if (err instanceof StravaError && err.status === 429) retryAt = nextStravaWindowMs();
+          else {
+            result.failed++;
+            log.error({ err, page }, "HR backfill Strava list page failed");
+          }
+          break;
+        }
+
+        for (const summary of summaries) {
+          if (!(summary.has_heartrate && summary.average_heartrate != null)) continue;
+          const local = byStravaId.get(summary.id);
+          if (!local) continue;
+          await activityRepo.updateSummaryHr(context.db, local.id, {
+            averageHeartRate: summary.average_heartrate,
+            maxHeartRate: summary.max_heartrate ?? null,
+            hasHeartrate: true,
+          });
+          result.summaryUpdated++;
+          byStravaId.delete(summary.id);
+        }
+
+        if (summaries.length < PAGE_SIZE) break;
+        if (overBudget(lastRateLimit)) {
+          retryAt = nextStravaWindowMs();
+          break;
+        }
+        await sleep(LIST_THROTTLE_MS);
+      }
+    }
+
+    // Phase B: compute stream stats for candidates missing them.
+    const candidates = await activityRepo.listHrStatsBackfillCandidates(context.db, userId);
+    let i = 0;
+    for (; i < candidates.length && i < MAX_STREAM_FETCHES_PER_RUN; i++) {
+      const row = candidates[i];
+      try {
+        await computeAndPersistRow(context.db, intervalsToken, stravaToken, row);
+        result.statsComputed++;
+      } catch (err) {
+        if (err instanceof StravaError && err.status === 429) {
+          retryAt ??= nextStravaWindowMs();
+          break;
+        }
+        result.failed++;
+        log.warn({ err, activityId: row.id }, "HR backfill stream computation failed");
+      }
+      await sleep(STREAM_THROTTLE_MS);
+      if ((i + 1) % PROGRESS_EVERY === 0) {
+        await publishSync(userId, {
+          kind: SYNC_KIND,
+          phase: "progress",
+          title: SYNC_TITLE,
+          messageKey: "hr_backfill_progress",
+          messageArgs: { done: String(i + 1), total: String(candidates.length) },
+        });
+      }
+    }
+    result.remaining = candidates.length - i;
+  } catch (err) {
+    result.failed++;
+    log.error({ err, userId }, "HR backfill failed");
+  } finally {
+    result.retryAt = retryAt;
+    activeBackfills.delete(userId);
+    await publishSync(userId, {
+      kind: SYNC_KIND,
+      phase: "completed",
+      title: SYNC_TITLE,
+      ...hrBackfillCompletedMessage(result, retryAt),
+      retryAt,
+    });
+  }
+
+  return result;
+}

--- a/src/services/intervals_link_service.ts
+++ b/src/services/intervals_link_service.ts
@@ -6,6 +6,7 @@ import { getIntervalsAccessToken } from "../middlewares/intervals_middleware";
 import { activities, type InsertActivity, users } from "../schema";
 import type { IGlobalBindings } from "../types/IRouters";
 import type { IIntervalsActivity } from "../types/intervals/IIntervalsActivity";
+import { userHasHeartRateConsent } from "./heart_rate_consent_service";
 import { intervalsApiService } from "./intervals_api_service";
 import { mapIntervalsActivityToInsert } from "./intervals_mappers";
 import { deleteProviderToken } from "./oauth_token_store";
@@ -16,6 +17,7 @@ type EnrichmentFields = Partial<
     InsertActivity,
     | "elapsedTime"
     | "maxHeartRate"
+    | "hasHeartrate"
     | "averagePower"
     | "weightedAveragePower"
     | "calories"
@@ -30,10 +32,12 @@ type EnrichmentFields = Partial<
   >
 >;
 
-function buildEnrichment(activity: IIntervalsActivity): EnrichmentFields {
-  return {
+function buildEnrichment(
+  activity: IIntervalsActivity,
+  processHeartRate: boolean,
+): EnrichmentFields {
+  const base: EnrichmentFields = {
     elapsedTime: activity.elapsed_time ?? null,
-    maxHeartRate: activity.max_heartrate ?? null,
     averagePower: activity.icu_average_watts ?? null,
     weightedAveragePower: activity.icu_weighted_avg_watts ?? null,
     calories: activity.calories ?? null,
@@ -45,6 +49,19 @@ function buildEnrichment(activity: IIntervalsActivity): EnrichmentFields {
     icuFtp: activity.icu_ftp ?? null,
     icuCtl: activity.icu_ctl ?? null,
     icuAtl: activity.icu_atl ?? null,
+  };
+  // GDPR consent gate: when HR processing is off, never persist HR from
+  // intervals.icu. Omit the HR fields entirely (rather than writing null) so an
+  // enrich pass over an existing row can't clobber HR another source legitimately
+  // stored under consent. Setting hasHeartrate only when true also repairs the
+  // flag intervals ingest historically never set.
+  if (!processHeartRate) return base;
+  return {
+    ...base,
+    maxHeartRate: activity.max_heartrate ?? null,
+    ...(activity.average_heartrate != null || activity.max_heartrate != null
+      ? { hasHeartrate: true }
+      : {}),
   };
 }
 
@@ -117,6 +134,7 @@ async function commitLink(
   context: IGlobalBindings,
   localActivityId: number,
   intervalsActivity: IIntervalsActivity,
+  processHeartRate: boolean,
 ): Promise<void> {
   await context.db
     .update(activities)
@@ -124,7 +142,7 @@ async function commitLink(
       intervalsIcuId: intervalsActivity.id,
       intervalsAnalyzed: true,
       intervalsIcuEnrichedAt: new Date(),
-      ...buildEnrichment(intervalsActivity),
+      ...buildEnrichment(intervalsActivity, processHeartRate),
     })
     .where(and(eq(activities.id, localActivityId), isNull(activities.intervalsIcuId)));
 }
@@ -146,7 +164,8 @@ export async function linkFromIntervalsActivity(
   const match = await findLocalByFuzzyMatch(context, user.id, intervalsActivity);
   if (!match) return null;
 
-  await commitLink(context, match.id, intervalsActivity);
+  const processHeartRate = await userHasHeartRateConsent(context.db, user.id);
+  await commitLink(context, match.id, intervalsActivity, processHeartRate);
   return { localActivityId: match.id, intervalsActivityId };
 }
 
@@ -166,6 +185,8 @@ export async function linkFromLocalActivity(
     },
   });
   if (!activity || activity.intervalsIcuId) return null;
+
+  const processHeartRate = await userHasHeartRateConsent(context.db, user.id);
 
   let accessToken: string;
   try {
@@ -204,7 +225,7 @@ export async function linkFromLocalActivity(
         logger.error({ err, intervalsActivityId: exact[0].id }, "intervals.icu getActivity failed");
         full = exact[0];
       }
-      await commitLink(context, activity.id, full);
+      await commitLink(context, activity.id, full, processHeartRate);
       return { localActivityId: activity.id, intervalsActivityId: full.id };
     }
   }
@@ -232,7 +253,7 @@ export async function linkFromLocalActivity(
     full = fuzzy[0];
   }
 
-  await commitLink(context, activity.id, full);
+  await commitLink(context, activity.id, full, processHeartRate);
   return { localActivityId: activity.id, intervalsActivityId: full.id };
 }
 
@@ -278,11 +299,12 @@ export async function enrichActivityFromIntervalsIcu(
     return "no_match";
   }
 
+  const processHeartRate = await userHasHeartRateConsent(context.db, user.id);
   await context.db
     .update(activities)
     .set({
       intervalsIcuEnrichedAt: new Date(),
-      ...buildEnrichment(full),
+      ...buildEnrichment(full, processHeartRate),
     })
     .where(eq(activities.id, activity.id));
 
@@ -393,6 +415,7 @@ export async function syncAllFromIntervals(
 
   try {
     const accessToken = await getIntervalsAccessToken(user.id);
+    const processHeartRate = await userHasHeartRateConsent(context.db, user.id);
 
     const localRows = await context.db
       .select({
@@ -477,18 +500,18 @@ export async function syncAllFromIntervals(
                 "intervals.icu getActivity failed during master sync — using list payload",
               );
             }
-            await commitLink(context, localMatch.id, full);
+            await commitLink(context, localMatch.id, full, processHeartRate);
             knownIntervalsIds.add(intervalsActivity.id);
             const idx = unlinkedLocals.indexOf(localMatch);
             if (idx >= 0) unlinkedLocals.splice(idx, 1);
             result.linked++;
           } else {
             const payload: InsertActivity = {
-              ...mapIntervalsActivityToInsert(intervalsActivity, user.id),
+              ...mapIntervalsActivityToInsert(intervalsActivity, user.id, processHeartRate),
               intervalsAnalyzed: true,
               intervalsIcuEnrichedAt: new Date(),
               analysisStatus: AUTO_ANALYZE_ON_IMPORT ? "pending" : "completed",
-              ...buildEnrichment(intervalsActivity),
+              ...buildEnrichment(intervalsActivity, processHeartRate),
             };
             await context.db.insert(activities).values(payload).onConflictDoNothing();
             knownIntervalsIds.add(intervalsActivity.id);

--- a/src/services/intervals_mappers.ts
+++ b/src/services/intervals_mappers.ts
@@ -22,7 +22,9 @@ function parseIntervalsLocalStart(value: string): Date {
 export function mapIntervalsActivityToInsert(
   activity: IIntervalsActivity,
   userId: string,
+  processHeartRate: boolean,
 ): InsertActivity {
+  const hasHr = activity.average_heartrate != null || activity.max_heartrate != null;
   return {
     userId,
     stravaActivityId: null,
@@ -35,7 +37,8 @@ export function mapIntervalsActivityToInsert(
     movingTime: activity.moving_time ?? 0,
     elapsedTime: activity.elapsed_time ?? null,
     totalElevationGain: activity.total_elevation_gain ?? null,
-    averageHeartRate: activity.average_heartrate ?? null,
+    averageHeartRate: processHeartRate ? (activity.average_heartrate ?? null) : null,
+    hasHeartrate: processHeartRate && hasHr,
     startDateLocal: parseIntervalsLocalStart(activity.start_date_local),
     indoor: activity.trainer ?? false,
   };

--- a/src/services/strava_link_service.ts
+++ b/src/services/strava_link_service.ts
@@ -91,13 +91,13 @@ function stravaCompletedMessage(
   return { messageKey: "sync_completed_strava", messageArgs: args };
 }
 
-function overBudget(rateLimit: StravaRateLimit | null): boolean {
+export function overBudget(rateLimit: StravaRateLimit | null): boolean {
   if (!rateLimit) return false;
   return rateLimit.shortTermUsage >= rateLimit.shortTermLimit - SHORT_TERM_SAFETY_MARGIN;
 }
 
 const FIFTEEN_MIN_MS = 15 * 60 * 1000;
-function nextStravaWindowMs(): number {
+export function nextStravaWindowMs(): number {
   return (Math.floor(Date.now() / FIFTEEN_MIN_MS) + 1) * FIFTEEN_MIN_MS;
 }
 

--- a/tests/hr_backfill.test.ts
+++ b/tests/hr_backfill.test.ts
@@ -1,0 +1,228 @@
+import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
+import { eq } from "drizzle-orm";
+
+// Controllable Strava API for the real runHrBackfill (only its HTTP dependency
+// is swapped, per file, delegating to mutable state). `listGate`, when set, lets
+// a test pin the job mid-Phase-A2 so it keeps holding its per-user lock.
+type SummaryPage = {
+  data: Array<Record<string, unknown>>;
+  rateLimit: {
+    shortTermUsage: number;
+    shortTermLimit: number;
+    dailyUsage: number;
+    dailyLimit: number;
+  } | null;
+};
+
+const mockState: {
+  summaryPages: SummaryPage[];
+  listCallCount: number;
+  listGate: Promise<void> | null;
+  streams: unknown;
+} = { summaryPages: [], listCallCount: 0, listGate: null, streams: null };
+
+let releaseGate: (() => void) | null = null;
+
+mock.module("../src/services/strava_api_service.ts", () => ({
+  stravaApiService: {
+    getActivity: async () => ({ id: 1, splits_metric: [] }),
+    getGear: async (_t: string, id: string) => ({
+      id,
+      name: `Mock Gear ${id}`,
+      distance: 0,
+      retired: false,
+    }),
+    getActivityStreams: async () => mockState.streams ?? {},
+    getActivityLaps: async () => [],
+    listAthleteActivities: async () => [],
+    listAthleteActivitiesWithMeta: async (_t: string, query: { page?: string }) => {
+      mockState.listCallCount++;
+      if (mockState.listGate) await mockState.listGate;
+      const idx = Number(query.page ?? "1") - 1;
+      return mockState.summaryPages[idx] ?? { data: [], rateLimit: null };
+    },
+    syncStravaActivities: async (_t: string, _u: string, ids: number[]) =>
+      ids.map((id) => ({ id, status: "success" as const })),
+  },
+}));
+
+import { activities } from "../src/schema";
+import { isHrBackfillRunning } from "../src/services/hr_backfill_service";
+import { closePool, createTestUser, deleteTestUser, getDb, getPool } from "./helpers/db";
+import { insertActivity } from "./helpers/fixtures";
+import { buildTestApp, withIdentity } from "./helpers/test_app";
+
+const app = buildTestApp(getPool());
+
+const createdUsers: string[] = [];
+
+async function newUser(opts?: Parameters<typeof createTestUser>[0]) {
+  const u = await createTestUser(opts);
+  createdUsers.push(u.id);
+  return u;
+}
+
+const identity = (u: { id: string; clerkId: string }) => ({
+  userId: u.id,
+  clerkUserId: u.clerkId,
+  role: "premium" as const,
+});
+
+async function setStats(
+  activityId: number,
+  fields: Partial<typeof activities.$inferInsert>,
+): Promise<void> {
+  await getDb().update(activities).set(fields).where(eq(activities.id, activityId));
+}
+
+function backfill() {
+  return app.fetch(
+    new Request("http://test/api/v1/heart-rate/backfill", { method: "POST" }),
+  );
+}
+
+async function waitFor(check: () => boolean | Promise<boolean>, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await check()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("condition not met within timeout");
+}
+
+afterEach(async () => {
+  releaseGate?.();
+  releaseGate = null;
+  // Let any in-flight background job release its per-user lock before cleanup.
+  for (const id of createdUsers) {
+    await waitFor(() => !isHrBackfillRunning(id), 3000).catch(() => {});
+  }
+  for (const id of createdUsers) await deleteTestUser(id);
+  createdUsers.length = 0;
+  mockState.summaryPages = [];
+  mockState.listCallCount = 0;
+  mockState.listGate = null;
+  mockState.streams = null;
+});
+
+afterAll(async () => {
+  await closePool();
+});
+
+describe("POST /api/v1/heart-rate/backfill", () => {
+  it("returns 403 and starts no job when the user has not enabled HR processing", async () => {
+    const user = await newUser({ processHeartRate: false });
+    await withIdentity(identity(user), async () => {
+      const res = await backfill();
+      expect(res.status).toBe(403);
+    });
+    expect(isHrBackfillRunning(user.id)).toBe(false);
+    expect(mockState.listCallCount).toBe(0);
+  });
+
+  it("returns 202 then backfills Strava summary HR and computes stream stats", async () => {
+    const user = await newUser({ processHeartRate: true, intervals: false });
+    const act = await insertActivity(user.id, { title: "Consent-off import" });
+    await setStats(act.id, {
+      hasHeartrate: false,
+      averageHeartRate: null,
+      maxHeartRate: null,
+      hrStatsComputedAt: null,
+    });
+
+    mockState.summaryPages = [
+      {
+        data: [
+          {
+            id: act.stravaActivityId,
+            has_heartrate: true,
+            average_heartrate: 150,
+            max_heartrate: 175,
+          },
+        ],
+        rateLimit: { shortTermUsage: 1, shortTermLimit: 100, dailyUsage: 1, dailyLimit: 1000 },
+      },
+    ];
+    mockState.streams = {
+      heartrate: { data: [148, 150, 152] },
+      time: { data: [0, 1, 2] },
+    };
+
+    await withIdentity(identity(user), async () => {
+      const res = await backfill();
+      expect(res.status).toBe(202);
+      expect(await res.json()).toEqual({ status: "started" });
+    });
+
+    await waitFor(async () => {
+      const [row] = await getDb()
+        .select({ computedAt: activities.hrStatsComputedAt })
+        .from(activities)
+        .where(eq(activities.id, act.id));
+      return row?.computedAt != null;
+    });
+
+    const [row] = await getDb()
+      .select({
+        avg: activities.averageHeartRate,
+        hasHeartrate: activities.hasHeartrate,
+        computedAt: activities.hrStatsComputedAt,
+      })
+      .from(activities)
+      .where(eq(activities.id, act.id));
+    expect(row.avg).toBe(150);
+    expect(row.hasHeartrate).toBe(true);
+    expect(row.computedAt).not.toBeNull();
+  });
+
+  it("returns 409 when a backfill is already running for the user", async () => {
+    const user = await newUser({ processHeartRate: true });
+    // Pin Phase A2's first list call so the first job keeps holding the lock.
+    mockState.listGate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+
+    await withIdentity(identity(user), async () => {
+      const first = await backfill();
+      expect(first.status).toBe(202);
+
+      await waitFor(() => isHrBackfillRunning(user.id));
+
+      const second = await backfill();
+      expect(second.status).toBe(409);
+    });
+  });
+
+  it("repairs the hasHeartrate flag with zero Strava calls when no Strava token", async () => {
+    const user = await newUser({ processHeartRate: true, strava: false, intervals: false });
+    const act = await insertActivity(user.id, { title: "Intervals-sourced" });
+    await setStats(act.id, {
+      stravaActivityId: null,
+      intervalsIcuId: "icu-hr-1",
+      hasHeartrate: false,
+      averageHeartRate: 140,
+      maxHeartRate: null,
+      hrStatsComputedAt: null,
+    });
+
+    await withIdentity(identity(user), async () => {
+      const res = await backfill();
+      expect(res.status).toBe(202);
+    });
+
+    await waitFor(async () => {
+      const [row] = await getDb()
+        .select({ computedAt: activities.hrStatsComputedAt })
+        .from(activities)
+        .where(eq(activities.id, act.id));
+      return row?.computedAt != null;
+    });
+
+    const [row] = await getDb()
+      .select({ hasHeartrate: activities.hasHeartrate })
+      .from(activities)
+      .where(eq(activities.id, act.id));
+    expect(row.hasHeartrate).toBe(true);
+    expect(mockState.listCallCount).toBe(0);
+  });
+});

--- a/tests/intervals_mappers.test.ts
+++ b/tests/intervals_mappers.test.ts
@@ -10,7 +10,7 @@ import { synthIntervalsActivity } from "./helpers/intervals_fixtures";
 describe("mapIntervalsActivityToInsert", () => {
   it("produces a null-Strava insert carrying the intervals.icu id", () => {
     const a = synthIntervalsActivity({ distance: 7200, name: "Tempo" });
-    const insert = mapIntervalsActivityToInsert(a, "user-1");
+    const insert = mapIntervalsActivityToInsert(a, "user-1", true);
 
     expect(insert.stravaActivityId).toBeNull();
     expect(insert.intervalsIcuId).toBe(a.id);
@@ -23,7 +23,7 @@ describe("mapIntervalsActivityToInsert", () => {
 
   it("parses intervals.icu's naive local time as a UTC instant", () => {
     const a = synthIntervalsActivity({ start_date_local: "2026-05-01T08:00:00" });
-    const insert = mapIntervalsActivityToInsert(a, "u");
+    const insert = mapIntervalsActivityToInsert(a, "u", true);
     expect(insert.startDateLocal.toISOString()).toBe("2026-05-01T08:00:00.000Z");
   });
 
@@ -36,11 +36,25 @@ describe("mapIntervalsActivityToInsert", () => {
       name: null,
       type: "Elliptical",
     });
-    const insert = mapIntervalsActivityToInsert(a, "u");
+    const insert = mapIntervalsActivityToInsert(a, "u", true);
     expect(insert.distance).toBe(0);
     expect(insert.movingTime).toBe(0);
     expect(insert.title).toBe("Untitled activity");
     expect(insert.sportType).toBe("Elliptical");
+  });
+
+  it("carries HR and sets hasHeartrate when consent is granted", () => {
+    const a = synthIntervalsActivity({ average_heartrate: 150 });
+    const insert = mapIntervalsActivityToInsert(a, "u", true);
+    expect(insert.averageHeartRate).toBe(150);
+    expect(insert.hasHeartrate).toBe(true);
+  });
+
+  it("nulls HR and clears hasHeartrate when consent is withheld (GDPR gate)", () => {
+    const a = synthIntervalsActivity({ average_heartrate: 150, max_heartrate: 175 });
+    const insert = mapIntervalsActivityToInsert(a, "u", false);
+    expect(insert.averageHeartRate).toBeNull();
+    expect(insert.hasHeartrate).toBe(false);
   });
 });
 


### PR DESCRIPTION
## HR backfill — backend

Enabling the "Process heart rate" consent toggle can now backfill a user's historical HR, and the intervals.icu ingest path is brought into line with the GDPR consent gate.

### New endpoint
`POST /api/v1/heart-rate/backfill` (`TGlobalEnv`, no Strava middleware — tokens resolved in-job so intervals-only users benefit): consent check → **403**, already-running → **409**, else fire-and-forget → **202** `{status:"started"}`.

### Background job (`hr_backfill_service.ts`)
In-memory, resumable (re-selects `hrStatsComputedAt IS NULL`), module-level double-trigger lock. SSE `hr_backfill` progress (`started` → `progress` every 25 rows → `completed`).
- **Phase A1** — local `hasHeartrate` flag repair (no API): fixes intervals-sourced rows that stored HR but never set the flag.
- **Phase A2** — Strava full-history summary pass: re-fetches HR nulled at consent-off ingest; budget/429-aware (`retryAt`).
- **Phase B** — stream-stat compute (`computeAndPersistRow`), 1 rps, 300/run cap.

### Consent-gate fix (the flagged inconsistency)
intervals.icu ingest previously stored `averageHeartRate` unconditionally and never set `hasHeartrate`, bypassing the `processHeartRate` gate that Strava ingest honours. Now `mapIntervalsActivityToInsert`/`buildEnrichment` take a `processHeartRate` flag resolved from `userHasHeartRateConsent` at each `intervals_link_service` entry (`syncAllFromIntervals`, `linkFrom*`, `enrichActivityFromIntervalsIcu`): consent-off nulls HR + clears the flag (enrich **omits** HR fields so it can't clobber another source's legitimately-stored HR); consent-on sets `hasHeartrate`. New ingest is now symmetric with Strava.

### Tests
`tests/hr_backfill.test.ts` (403 / 202+effects / 409 double-trigger / intervals flag-repair with zero Strava calls) + consent-gate cases in `intervals_mappers.test.ts`. `bun run check` green: **543 pass**, tsc + biome clean.

Pairs with IntervalInsights-app#hr-backfill (settings prompt, SSE progress toasts, HR-entry consent gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)