### PR TITLE
Text-declared structure is authority in the analyze pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Every activity flows through a single graph, paused mid-way for user confirmatio
 
 **Auto-retry for errors**: `error` activities with `analysisAttemptCount < 2` are retried automatically by `/pending`. After two failures the user must manually retry.
 
-**Idempotency**: `startAnalysis` and `restartAnalysisByStravaId` skip activities already in `{ongoing_init, ongoing_completed, initial, completed, skipped_inactive}`. GET endpoints NEVER trigger analysis.
+**Idempotency**: `startAnalysis` and `triggerAnalysisByStravaId` skip activities already in `{ongoing_init, ongoing_completed, initial, completed, skipped_inactive}`. GET endpoints NEVER trigger analysis.
 
 **Agents** (`src/agent/`):
 - `initial_analysis_agent.ts` — classify + draft structure, with optional intervals.icu prediction block.
@@ -141,7 +141,7 @@ Layered deterrence against non-app clients using the backend as a free API. MCP 
 **Tier 1b — per-user daily quotas on LLM-backed endpoints** (`src/middlewares/quota_middleware.ts`, always on, in-memory per UTC day). Generous by design — a real user never hits them; the analysis cap is a circuit breaker against scripted model spend:
 - `POST /api/v1/agents/suggest-session` — 100/user/day (429 over cap)
 - `POST /api/v1/agents/parse-intervals` — 100/user/day (429)
-- Analysis starts — 1000/user/day, shared bucket across `/start-analysis`, `/resume-analysis` (429), the Strava import fan-out (`strava_api_router.ts` callback) and requeue retries (`requeue_service.ts`) — the last two are background, so they skip-and-warn rather than 429. A batch import of N ids counts N against the cap but is still one request. Webhook auto-analysis (`startAnalysisByStravaId`) is not counted. A warn fires as a user crosses 80%.
+- Analysis starts — 1000/user/day, shared bucket across `/start-analysis`, `/resume-analysis` (429), the Strava import fan-out (`strava_api_router.ts` callback) and requeue retries (`requeue_service.ts`) — the last two are background, so they skip-and-warn rather than 429. A batch import of N ids counts N against the cap but is still one request. Webhook auto-analysis (`triggerAnalysisByStravaId`, via `process_strava_event.ts`) is not counted. A warn fires as a user crosses 80%.
 
 **Tier 2 — app client key** (`src/middlewares/client_key_middleware.ts`, `clientKeyGuard`). Deterrence-only (Clerk-publishable-key pattern): the app sends a shared secret as `x-client-key`; nothing here proves app origin (only device attestation could). Mounted on `/api/*` in `src/index.ts` **after** the public routes (so webhooks/health/legal, whose handlers terminate the chain, stay open) and **before** the Better Auth handler (so OTP send/verify is gated too). Controlled by `APP_CLIENT_KEY` / `APP_CLIENT_KEY_MODE` (see env section): unset ⇒ off; `log` ⇒ warn-and-pass (the rollout phase, while already-installed builds send no header); `enforce` ⇒ 401. Do **not** flip to `enforce` until the app release that sends the header is live (and ideally the Phase 6 cutover) — enforcing early bricks every installed build.
 

--- a/src/agent/graph_state.ts
+++ b/src/agent/graph_state.ts
@@ -50,6 +50,13 @@ export const AnalysisStateAnnotation = Annotation.Root({
     default: () => null,
   }),
   lapsMatchStructure: Annotation<boolean>({ reducer: overwrite, default: () => false }),
+  // Provenance of the authoritative structure: "text" (title/description),
+  // "notes" (resume-time notes), or "model". Anything other than "model" tells
+  // segment production a text-declared rep count must be enforced.
+  structureSource: Annotation<"model" | "text" | "notes">({
+    reducer: overwrite,
+    default: () => "model",
+  }),
 
   userNotes: Annotation<string>({ reducer: overwrite, default: () => "" }),
   userSets: Annotation<ExpandedIntervalSet[]>({ reducer: overwrite, default: () => [] }),

--- a/src/agent/initial_analysis_agent.ts
+++ b/src/agent/initial_analysis_agent.ts
@@ -130,13 +130,10 @@ function formatIntervalsIcuBlock(prediction: IntervalsIcuPrediction | null | und
       return `| ${idx + 1} | ${i.type} | ${i.distance}m | ${i.moving_time}s | ${pace} | ${hr} | ${load} |`;
     })
     .join("\n");
-  const typeHint = prediction.trainingType
-    ? `intervals.icu suggests training type: **${prediction.trainingType}**${prediction.subType ? ` (sub: ${prediction.subType})` : ""}.`
-    : "";
   const tableBlock = rows
     ? `\n| # | Type | Distance | Time | Avg pace | Avg HR | Load |\n|---|------|----------|------|----------|--------|------|\n${rows}`
     : "";
-  return `\n  ### INTERVALS.ICU PREDICTION (treat as a strong hint, not ground truth)\n  ${typeHint}${tableBlock}\n`;
+  return `\n  ### INTERVALS.ICU PREDICTION (treat as a strong hint, not ground truth)\n  ${tableBlock}\n`;
 }
 
 /**

--- a/src/agent/initial_analysis_agent.ts
+++ b/src/agent/initial_analysis_agent.ts
@@ -8,6 +8,7 @@ import type { StreamSet } from "../types/strava/IStream";
 import { buildLapEvidenceBlock } from "./lap_evidence";
 import { gptMiniModel, invokeStructured } from "./model";
 import { venuePromptBlock } from "./running_venues";
+import { STRUCTURE_EXTRACTION_RULES } from "./structure_prompt_rules";
 export type WorkoutAnalysisOutput = z.infer<typeof workoutAnalysisOutput>;
 
 export const workoutStep = z.object({
@@ -157,13 +158,12 @@ function formatIntervalsIcuBlock(prediction: IntervalsIcuPrediction | null | und
  * SHORT/LONG gate). Runs before reconcileIntervalSubtype so the gate sees the fixed
  * structure. A genuine sequence ("3,2,1 km") has reps:1 per step and is untouched.
  */
-export function reconcileStructureBlowup(
-  out: z.infer<typeof workoutAnalysisOutput>,
-): z.infer<typeof workoutAnalysisOutput> {
-  const structure = out.structure;
-  if (!structure || structure.length === 0) return out;
+export function reconcileSetsBlowup(
+  sets: z.infer<typeof workoutSet>[],
+): z.infer<typeof workoutSet>[] {
+  if (sets.length === 0) return sets;
   let changed = false;
-  const fixed = structure.map((set) => {
+  const fixed = sets.map((set) => {
     const steps = set.steps;
     if (steps.length < 3) return set;
     const r = steps[0].reps;
@@ -179,7 +179,16 @@ export function reconcileStructureBlowup(
       steps: [{ ...steps[0], reps: r, work_value: Math.round(median) }],
     };
   });
-  return changed ? { ...out, structure: fixed } : out;
+  return changed ? fixed : sets;
+}
+
+export function reconcileStructureBlowup(
+  out: z.infer<typeof workoutAnalysisOutput>,
+): z.infer<typeof workoutAnalysisOutput> {
+  const structure = out.structure;
+  if (!structure || structure.length === 0) return out;
+  const fixed = reconcileSetsBlowup(structure);
+  return fixed === structure ? out : { ...out, structure: fixed };
 }
 
 export function reconcileIntervalSubtype(
@@ -265,15 +274,8 @@ ${sportContextBlock(type)}
 ${intervalsIcuBlock}${lapEvidenceBlock}
   ### 4. STRUCTURE EXTRACTION RULES (Hierarchical)
   You must populate the 'structure' array (an array of Sets) using these rules:
-  
-  1. **Identify Repeating Series:** - For a simple workout like **10x1000m**: Create one Set with **set_reps: 1** and one Step with **reps: 10**.
-     - For a complex workout like **3x (3km + 2km + 1km)**: Create one Set with **set_reps: 3**. Inside that set, create three Steps (3000m, 2000m, 1000m) each with **reps: 1**.
-  2. **Handle Set Recovery:** If there is a distinct longer break between large sets (e.g., 5 mins between blocks of intervals), put that in **set_recovery**.
-  3. **Ignore Warmup/Cooldown:** Only capture the "work" segments.
-  4. **Units:** Always convert distance to METERS and time to SECONDS.
-  5. **Comma-separated values are a STEP LIST, not decimals (Norwegian list notation):** "3,2,1 km" = three Steps of 3 km, 2 km, 1 km (→ 3000m, 2000m, 1000m); "2 x 3,2,2 km" = one Set with **set_reps: 2** and three Steps (3000m, 2000m, 2000m). A comma between numbers in such a list is a SEPARATOR, never a decimal point.
-  6. **"N x (a, b, c)" = N SETS of the sequence a→b→c.** Set **set_reps: N** and create ONE Step per item (reps: 1 each), so the sequence repeats a,b,c / a,b,c / … — e.g. **"5 x (3,2,1 min)"** = set_reps: 5, Steps [180s, 120s, 60s] each reps: 1; **"3x (3km + 2km + 1km)"** = set_reps: 3, Steps [3000m, 2000m, 1000m]. **Do NOT** create 3 Steps with reps: N (that wrongly groups all the a's, then all the b's, then all the c's).
-  7. **Compound / sequential workouts = ONE Set PER BLOCK — capture EVERY block.** When the title chains distinct interval blocks, emit a SEPARATE Set for each block in order, and never drop the trailing block(s). Triggers include English "X followed by Y", "X then Y", and Norwegian "X etterfulgt av Y", "X deretter Y", "X så Y", or a top-level "X + Y" joining two different rep schemes. E.g. **"4x1000m etterfulgt av 20x45/15"** = TWO Sets: Set 1 (set_reps: 1, one Step reps: 4, DISTANCE 1000m) and Set 2 (set_reps: 1, one Step reps: 20, TIME 45s work / 15s recovery). (Distinguish from rule 6's "N x (a,b,c)", which is ONE block repeated.)
+
+  ${STRUCTURE_EXTRACTION_RULES}
 
   ${venuePromptBlock()}
 

--- a/src/agent/nodes/await_user_input.ts
+++ b/src/agent/nodes/await_user_input.ts
@@ -4,6 +4,7 @@ import { logger } from "../../logger";
 import { trainingTypeEnum } from "../../schema/enums";
 import { EditedSegmentSchema, ExpandedIntervalSetSchema } from "../../schemas/api_schemas";
 import {
+  applyPartialCompletion,
   extractDeclaredStructure,
   rebuildSetsWithDeclaredPaces,
 } from "../../services/text_intent_service";
@@ -54,19 +55,35 @@ export async function awaitUserInput(state: AnalysisState): Promise<Partial<Anal
   // failure keeps the user's original sets.
   let structureSource: "model" | "text" | "notes" = state.structureSource ?? "model";
   try {
-    const notesDeclared = await extractDeclaredStructure(
-      [userInput.notes],
-      confirmedTrainingType ?? state.initialResult?.training_type,
-    );
-    if (notesDeclared) {
+    // Try the deterministic "N of M" completion first (free, no LLM): the notes
+    // name no distances/durations, so the parse agent correctly returns nothing —
+    // "8 av 10" refers to the EXISTING structure. Only fall through to the parse
+    // path when the notes declare a NEW structure.
+    const partial = applyPartialCompletion(userInput.notes, userSets);
+    if (partial) {
       const prevWorkSteps = userSets.reduce((n, s) => n + s.steps.length, 0);
-      userSets = rebuildSetsWithDeclaredPaces(notesDeclared, userSets);
+      userSets = partial;
       const newWorkSteps = userSets.reduce((n, s) => n + s.steps.length, 0);
       structureSource = "notes";
       log.info(
         { prevWorkSteps, newWorkSteps },
-        "notes declared a structure — userSets rebuilt toward notes",
+        "notes reported partial completion — userSets truncated to completed steps",
       );
+    } else {
+      const notesDeclared = await extractDeclaredStructure(
+        [userInput.notes],
+        confirmedTrainingType ?? state.initialResult?.training_type,
+      );
+      if (notesDeclared) {
+        const prevWorkSteps = userSets.reduce((n, s) => n + s.steps.length, 0);
+        userSets = rebuildSetsWithDeclaredPaces(notesDeclared, userSets);
+        const newWorkSteps = userSets.reduce((n, s) => n + s.steps.length, 0);
+        structureSource = "notes";
+        log.info(
+          { prevWorkSteps, newWorkSteps },
+          "notes declared a structure — userSets rebuilt toward notes",
+        );
+      }
     }
   } catch (err) {
     log.warn({ err }, "notes reconciliation failed — keeping user sets");

--- a/src/agent/nodes/await_user_input.ts
+++ b/src/agent/nodes/await_user_input.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import { logger } from "../../logger";
 import { trainingTypeEnum } from "../../schema/enums";
 import { EditedSegmentSchema, ExpandedIntervalSetSchema } from "../../schemas/api_schemas";
+import {
+  extractDeclaredStructure,
+  rebuildSetsWithDeclaredPaces,
+} from "../../services/text_intent_service";
 import { generateCompleteIntervalSet } from "../../services/utils";
 import type { ExpandedIntervalSet } from "../../types/ExpandedIntervalSet";
 import type { AnalysisState } from "../graph_state";
@@ -41,6 +45,33 @@ export async function awaitUserInput(state: AnalysisState): Promise<Partial<Anal
     log.info({ sets: userSets.length }, "hydrated empty userSets from initialResult.structure");
   }
 
+  const confirmedTrainingType = userInput.trainingType ?? null;
+
+  // Notes beat title/description (newer + deliberate): if the resume-time notes
+  // declare a structure ("only did 8 of 10"), rebuild userSets toward them,
+  // carrying the previously-proposed paces over positionally. Generic/empty notes
+  // fail the prefilter inside extractDeclaredStructure and cost no LLM call. Any
+  // failure keeps the user's original sets.
+  let structureSource: "model" | "text" | "notes" = state.structureSource ?? "model";
+  try {
+    const notesDeclared = await extractDeclaredStructure(
+      [userInput.notes],
+      confirmedTrainingType ?? state.initialResult?.training_type,
+    );
+    if (notesDeclared) {
+      const prevWorkSteps = userSets.reduce((n, s) => n + s.steps.length, 0);
+      userSets = rebuildSetsWithDeclaredPaces(notesDeclared, userSets);
+      const newWorkSteps = userSets.reduce((n, s) => n + s.steps.length, 0);
+      structureSource = "notes";
+      log.info(
+        { prevWorkSteps, newWorkSteps },
+        "notes declared a structure — userSets rebuilt toward notes",
+      );
+    }
+  } catch (err) {
+    log.warn({ err }, "notes reconciliation failed — keeping user sets");
+  }
+
   log.info(
     {
       notesLen: userInput?.notes?.length ?? 0,
@@ -54,8 +85,9 @@ export async function awaitUserInput(state: AnalysisState): Promise<Partial<Anal
   return {
     userNotes: userInput.notes ?? "",
     userSets,
-    confirmedTrainingType: userInput.trainingType ?? null,
+    confirmedTrainingType,
     feeling: userInput.feeling ?? null,
     userEditedSegments: userInput.editedSegments ?? [],
+    structureSource,
   };
 }

--- a/src/agent/nodes/propose_segments.ts
+++ b/src/agent/nodes/propose_segments.ts
@@ -58,7 +58,6 @@ export async function proposeSegments(
     isIndoor: state.isIndoor,
     userSets: draftSets,
     initialResult: state.initialResult,
-    userNotes: "",
     trainingType,
     intervalsIcuIntervals: state.intervalsIcuPrediction?.intervals ?? null,
     declaredReps:

--- a/src/agent/nodes/propose_segments.ts
+++ b/src/agent/nodes/propose_segments.ts
@@ -7,7 +7,7 @@ import { generateCompleteIntervalSet, needCompleteAnalysis } from "../../service
 import type { ExpandedIntervalSet } from "../../types/ExpandedIntervalSet";
 import type { StreamSet } from "../../types/strava/IStream";
 import type { AnalysisState, GraphConfigurable } from "../graph_state";
-import { produceSegments } from "../segment_production";
+import { countStructureReps, produceSegments } from "../segment_production";
 
 export async function proposeSegments(
   state: AnalysisState,
@@ -61,6 +61,10 @@ export async function proposeSegments(
     userNotes: "",
     trainingType,
     intervalsIcuIntervals: state.intervalsIcuPrediction?.intervals ?? null,
+    declaredReps:
+      state.structureSource !== "model"
+        ? countStructureReps(state.initialResult?.structure)
+        : undefined,
     log,
     tag: `[proposeSegments activity=${state.activityId}]`,
   });

--- a/src/agent/nodes/run_complete_analysis.ts
+++ b/src/agent/nodes/run_complete_analysis.ts
@@ -71,6 +71,10 @@ export async function runCompleteAnalysis(
       userNotes: state.userNotes,
       trainingType,
       intervalsIcuIntervals: state.intervalsIcuPrediction?.intervals ?? null,
+      declaredReps:
+        state.structureSource !== "model"
+          ? state.userSets.reduce((n, s) => n + s.steps.length, 0)
+          : undefined,
       log,
       tag: `[runCompleteAnalysis activity=${state.activityId}]`,
     });

--- a/src/agent/nodes/run_complete_analysis.ts
+++ b/src/agent/nodes/run_complete_analysis.ts
@@ -3,7 +3,11 @@ import { eq } from "drizzle-orm";
 import { logger } from "../../logger";
 import { activities } from "../../schema";
 import { INTERVAL_TRAINING_TYPES, isPowerSport } from "../../schema/enums";
-import { mapBoundariesToSegments, toBoundaries } from "../../services/segment_mapping_service";
+import {
+  boundariesMatchUserShape,
+  mapBoundariesToSegments,
+  toBoundaries,
+} from "../../services/segment_mapping_service";
 import { needCompleteAnalysis } from "../../services/utils";
 import type { StreamSet } from "../../types/strava/IStream";
 import type { AnalysisState, GraphConfigurable, SegmentBoundary } from "../graph_state";
@@ -46,7 +50,8 @@ export async function runCompleteAnalysis(
       `[runCompleteAnalysis activity=${state.activityId}] streams missing time or distance — cannot compute segment stats`,
     );
   }
-  const statsStreams = state.streams as Required<Pick<StreamSet, "time" | "distance">> &
+  const streams = state.streams;
+  const statsStreams = streams as Required<Pick<StreamSet, "time" | "distance">> &
     Pick<StreamSet, "heartrate">;
 
   await db
@@ -54,16 +59,12 @@ export async function runCompleteAnalysis(
     .set({ analysisStatus: "ongoing_completed", analysisStartedAt: new Date() })
     .where(eq(activities.id, state.activityId));
 
-  const boundaries: SegmentBoundary[] = state.userEditedSegments.length
-    ? state.userEditedSegments
-    : toBoundaries(state.proposedSegments);
-
-  if (boundaries.length === 0) {
-    log.warn("no edited or proposed segments — falling back to inline produceSegments (legacy)");
-    const fallback = await produceSegments({
+  const deriveFromUserShape = (reason: string) => {
+    log.warn(reason);
+    return produceSegments({
       activityId: state.activityId,
       statsStreams,
-      streams: state.streams,
+      streams,
       laps: state.laps,
       isIndoor: state.isIndoor,
       userSets: state.userSets,
@@ -73,13 +74,39 @@ export async function runCompleteAnalysis(
       intervalsIcuIntervals: state.intervalsIcuPrediction?.intervals ?? null,
       declaredReps:
         state.structureSource !== "model"
-          ? state.userSets.reduce((n, s) => n + s.steps.length, 0)
+          ? state.userSets.reduce((n, s) => n + s.steps.length, 0) || undefined
           : undefined,
       log,
       tag: `[runCompleteAnalysis activity=${state.activityId}]`,
     });
+  };
+
+  const hasEdits = state.userEditedSegments.length > 0;
+  const boundaries: SegmentBoundary[] = hasEdits
+    ? state.userEditedSegments
+    : toBoundaries(state.proposedSegments);
+
+  if (boundaries.length === 0) {
+    const fallback = await deriveFromUserShape(
+      "no edited or proposed segments — falling back to inline produceSegments (legacy)",
+    );
     log.info({ computedSegments: fallback.length }, "computed segments (legacy fallback)");
     return { computedSegments: fallback };
+  }
+
+  // D5: user's explicit boundary edits always win. But when boundaries come from
+  // the stale proposal and their work count disagrees with the (possibly
+  // notes-reconciled) userSets, mapping labels onto them would ship the wrong rep
+  // count — re-derive boundaries from the user shape instead.
+  if (!hasEdits && !boundariesMatchUserShape(boundaries, state.userSets)) {
+    const rederived = await deriveFromUserShape(
+      "proposed boundaries disagree with user shape — re-deriving segments from user sets",
+    );
+    log.info(
+      { computedSegments: rederived.length },
+      "computed segments (re-derived, boundary/sets mismatch)",
+    );
+    return { computedSegments: rederived };
   }
 
   const computedSegments = mapBoundariesToSegments(
@@ -91,7 +118,7 @@ export async function runCompleteAnalysis(
   );
 
   log.info(
-    { computedSegments: computedSegments.length, fromEdits: state.userEditedSegments.length > 0 },
+    { computedSegments: computedSegments.length, fromEdits: hasEdits },
     "computed segments (deterministic mapping)",
   );
   return { computedSegments };

--- a/src/agent/nodes/run_initial_agent.ts
+++ b/src/agent/nodes/run_initial_agent.ts
@@ -2,9 +2,13 @@ import type { RunnableConfig } from "@langchain/core/runnables";
 import { eq } from "drizzle-orm";
 import { logger } from "../../logger";
 import { activities, type DraftAnalysisResult } from "../../schema";
+import {
+  extractDeclaredStructure,
+  reconcileStructureTowardDeclared,
+} from "../../services/text_intent_service";
 import { lapsMatchIntervals, needCompleteAnalysis } from "../../services/utils";
 import type { AnalysisState, GraphConfigurable } from "../graph_state";
-import { invokeActivityAnalysisAgent } from "../initial_analysis_agent";
+import { invokeActivityAnalysisAgent, type WorkoutAnalysisOutput } from "../initial_analysis_agent";
 import { ANALYSIS_VERSION, invokeWithRateLimitRetry } from "../model";
 
 export async function runInitialAgent(
@@ -36,15 +40,44 @@ export async function runInitialAgent(
     throw new Error("Initial analysis agent returned null");
   }
 
+  // Text authority: when the title/description explicitly declares a structure,
+  // it wins on SHAPE over the model's stream-derived reading. Generic titles pass
+  // the deterministic prefilter and cost zero extra LLM calls.
+  const declaredStructure = await extractDeclaredStructure(
+    [state.activityTitle, state.activityDescription],
+    initialResult.training_type,
+  );
+  let finalResult = initialResult;
+  let structureSource: "text" | "model" = "model";
+  if (declaredStructure) {
+    const { result, changed } = reconcileStructureTowardDeclared(initialResult, declaredStructure);
+    finalResult = result;
+    structureSource = "text";
+    if (changed) {
+      log.info(
+        {
+          structureSource: "text",
+          modelReps: countReps(initialResult.structure),
+          declaredReps: countReps(result.structure),
+          modelType: initialResult.training_type,
+          declaredType: result.training_type,
+        },
+        "structure reconciled toward declared text",
+      );
+    }
+  }
+
   const lapsMatchStructure =
     !state.isIndoor &&
-    needCompleteAnalysis(initialResult.training_type) &&
-    lapsMatchIntervals(state.laps, initialResult);
+    needCompleteAnalysis(finalResult.training_type) &&
+    lapsMatchIntervals(state.laps, finalResult);
 
   const draft: DraftAnalysisResult = {
-    ...initialResult,
+    ...finalResult,
     lapsMatchStructure,
     intervalsIcuPrediction: state.intervalsIcuPrediction,
+    structureSource,
+    declaredStructure: declaredStructure ?? null,
   };
 
   await db
@@ -57,7 +90,7 @@ export async function runInitialAgent(
     })
     .where(eq(activities.id, state.activityId));
 
-  const structureSummary = (initialResult.structure ?? [])
+  const structureSummary = (finalResult.structure ?? [])
     .map(
       (s) =>
         `${s.set_reps}×[${s.steps.map((st) => `${st.reps}×${st.work_value}${st.work_type === "DISTANCE" ? "m" : "s"}`).join("+")}]`,
@@ -65,13 +98,24 @@ export async function runInitialAgent(
     .join(" | ");
   log.info(
     {
-      trainingType: initialResult.training_type,
-      confidence: Number(initialResult.confidence_score.toFixed(2)),
+      trainingType: finalResult.training_type,
+      confidence: Number(finalResult.confidence_score.toFixed(2)),
       lapsMatchStructure,
+      structureSource,
       structure: structureSummary || null,
     },
     "initialResult ready",
   );
 
-  return { initialResult, lapsMatchStructure };
+  return { initialResult: finalResult, lapsMatchStructure, structureSource };
+}
+
+/** Total work reps implied by a structure (set_reps × Σ step.reps), for logging. */
+function countReps(structure: WorkoutAnalysisOutput["structure"]): number {
+  if (!structure) return 0;
+  let n = 0;
+  for (const set of structure) {
+    n += (set.set_reps ?? 1) * set.steps.reduce((s, st) => s + (st.reps ?? 1), 0);
+  }
+  return n;
 }

--- a/src/agent/nodes/run_initial_agent.ts
+++ b/src/agent/nodes/run_initial_agent.ts
@@ -8,8 +8,9 @@ import {
 } from "../../services/text_intent_service";
 import { lapsMatchIntervals, needCompleteAnalysis } from "../../services/utils";
 import type { AnalysisState, GraphConfigurable } from "../graph_state";
-import { invokeActivityAnalysisAgent, type WorkoutAnalysisOutput } from "../initial_analysis_agent";
+import { invokeActivityAnalysisAgent } from "../initial_analysis_agent";
 import { ANALYSIS_VERSION, invokeWithRateLimitRetry } from "../model";
+import { countStructureReps } from "../segment_production";
 
 export async function runInitialAgent(
   state: AnalysisState,
@@ -57,8 +58,8 @@ export async function runInitialAgent(
       log.info(
         {
           structureSource: "text",
-          modelReps: countReps(initialResult.structure),
-          declaredReps: countReps(result.structure),
+          modelReps: countStructureReps(initialResult.structure) ?? 0,
+          declaredReps: countStructureReps(result.structure) ?? 0,
           modelType: initialResult.training_type,
           declaredType: result.training_type,
         },
@@ -108,14 +109,4 @@ export async function runInitialAgent(
   );
 
   return { initialResult: finalResult, lapsMatchStructure, structureSource };
-}
-
-/** Total work reps implied by a structure (set_reps × Σ step.reps), for logging. */
-function countReps(structure: WorkoutAnalysisOutput["structure"]): number {
-  if (!structure) return 0;
-  let n = 0;
-  for (const set of structure) {
-    n += (set.set_reps ?? 1) * set.steps.reduce((s, st) => s + (st.reps ?? 1), 0);
-  }
-  return n;
 }

--- a/src/agent/parse_intervals_agent.ts
+++ b/src/agent/parse_intervals_agent.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import type { TrainingType } from "../schema/enums";
-import { workoutSet } from "./initial_analysis_agent";
+import { reconcileSetsBlowup, workoutSet } from "./initial_analysis_agent";
 import { invokeStructured, isRateLimitError } from "./model";
 import { venuePromptBlock } from "./running_venues";
+import { STRUCTURE_EXTRACTION_RULES } from "./structure_prompt_rules";
 
 export const parseIntervalsOutput = z.object({
   sets: z
@@ -26,15 +27,8 @@ export async function invokeParseIntervalsAgent(
 You convert a user's free-text description of a structured workout into a typed list of workout sets.
 
 ### RULES
-- One Set per repeating series. **10x1000m** → 1 Set, set_reps=1, 1 Step with reps=10.
-- **3x(3km+2km+1km)** → 1 Set, set_reps=3, 3 Steps (3000m, 2000m, 1000m) each with reps=1.
-- Always convert distance to **METERS** and time to **SECONDS**.
-- Comma-separated values are a STEP LIST, not decimals: "3,2,1 km" → 3 Steps (3000m, 2000m, 1000m); "2 x 3,2,2 km" → set_reps=2 with 3 Steps (3000m, 2000m, 2000m). A comma here is a separator, NOT a decimal point.
-- **"N x (a, b, c)" = N SETS of the sequence a→b→c**: set_reps=N, one Step per item (reps=1) — e.g. "5 x (3,2,1 min)" → set_reps=5, Steps [180s, 120s, 60s]. Do NOT create 3 Steps with reps=N (that groups all a's, then all b's).
-- **Compound / sequential workouts = ONE Set PER BLOCK, capture EVERY block**: when the text chains distinct blocks ("X followed by Y", "X then Y", Norwegian "etterfulgt av" / "deretter" / "så", or a top-level "X + Y" of two different schemes), emit a separate Set per block in order and never drop the trailing block — e.g. "4x1000m etterfulgt av 20x45/15" → Set 1 (reps=4, 1000m DISTANCE) + Set 2 (reps=20, 45s/15s TIME).
-- Recovery between reps goes on the Step. Recovery between sets goes on the Set.
-- Ignore warmup/cooldown — only capture the "work" segments.
-- Return an empty 'sets' array if the text doesn't describe a structured workout.
+${STRUCTURE_EXTRACTION_RULES}
+8. **Return an empty 'sets' array if the text doesn't describe a structured workout.**
 ${typeHint}
 
 ${venuePromptBlock()}
@@ -46,7 +40,10 @@ ${venuePromptBlock()}
 Return the structured sets.
 `;
 
-  return invokeStructured(parseIntervalsOutput, prompt, "parse intervals from text").catch((err) =>
-    isRateLimitError(err) ? null : Promise.reject(err),
-  );
+  const result = await invokeStructured(
+    parseIntervalsOutput,
+    prompt,
+    "parse intervals from text",
+  ).catch((err) => (isRateLimitError(err) ? null : Promise.reject(err)));
+  return result ? { ...result, sets: reconcileSetsBlowup(result.sets) } : result;
 }

--- a/src/agent/segment_production.ts
+++ b/src/agent/segment_production.ts
@@ -61,7 +61,7 @@ export async function produceSegments(params: {
   isIndoor: boolean;
   userSets: ExpandedIntervalSet[];
   initialResult: WorkoutAnalysisOutput | null;
-  userNotes: string;
+  userNotes?: string;
   trainingType: TrainingType;
   intervalsIcuIntervals?: IIntervalsInterval[] | null;
   // Authoritative work-rep count from a text/notes-declared structure. When set,
@@ -73,6 +73,7 @@ export async function produceSegments(params: {
 }): Promise<InsertIntervalSegment[]> {
   const { activityId, statsStreams, streams, laps, userSets, initialResult, log } = params;
   const t0 = statsStreams.time.data[0] ?? 0;
+  const userNotes = params.userNotes ?? "";
   const declaredReps = params.declaredReps;
   const workCount = (segments: InsertIntervalSegment[]): number =>
     segments.filter((s) => s.type === "INTERVALS").length;
@@ -154,7 +155,7 @@ export async function produceSegments(params: {
   const segmentPlan = await invokeWithRateLimitRetry(() =>
     invokeCompleteActivityAnalysisAgent(
       streams,
-      params.userNotes,
+      userNotes,
       params.trainingType,
       laps,
       initialResult,

--- a/src/agent/segment_production.ts
+++ b/src/agent/segment_production.ts
@@ -41,7 +41,9 @@ export function ensureWarmupFirst(
 }
 
 /** Total work reps implied by an LLM-extracted structure (set_reps × Σ step.reps). */
-function countStructureReps(structure: WorkoutAnalysisOutput["structure"]): number | undefined {
+export function countStructureReps(
+  structure: WorkoutAnalysisOutput["structure"],
+): number | undefined {
   if (!structure || structure.length === 0) return undefined;
   let n = 0;
   for (const set of structure) {
@@ -62,18 +64,25 @@ export async function produceSegments(params: {
   userNotes: string;
   trainingType: TrainingType;
   intervalsIcuIntervals?: IIntervalsInterval[] | null;
+  // Authoritative work-rep count from a text/notes-declared structure. When set,
+  // a rung whose produced work count contradicts it is rejected (falls through to
+  // the next rung) rather than shipping the wrong count. Undefined ⇒ no change.
+  declaredReps?: number;
   log: Logger;
   tag: string;
 }): Promise<InsertIntervalSegment[]> {
   const { activityId, statsStreams, streams, laps, userSets, initialResult, log } = params;
   const t0 = statsStreams.time.data[0] ?? 0;
+  const declaredReps = params.declaredReps;
+  const workCount = (segments: InsertIntervalSegment[]): number =>
+    segments.filter((s) => s.type === "INTERVALS").length;
 
   // Preferred rung: when the activity is linked to intervals.icu, its own
   // WORK/RECOVERY breakdown is authoritative — use it before any heuristic.
   const intervalsIcu = params.intervalsIcuIntervals;
   if (intervalsIcu && intervalsIcu.length > 0) {
     log.info({ intervals: intervalsIcu.length }, "intervals.icu linked — attempting its breakdown");
-    const expectedReps = countStructureReps(initialResult?.structure);
+    const expectedReps = declaredReps ?? countStructureReps(initialResult?.structure);
     const fromIcu = buildSegmentsFromIntervalsIcu(
       activityId,
       intervalsIcu,
@@ -93,10 +102,19 @@ export async function produceSegments(params: {
     log.info("structure unchanged — attempting lap-derived segments");
     const fromLaps = buildSegmentsFromLaps(activityId, laps, userSets, statsStreams, params.tag);
     if (fromLaps) {
-      log.info({ segments: fromLaps.length }, "lap-derived segments");
-      return ensureWarmupFirst(fromLaps, activityId, t0);
+      const reps = workCount(fromLaps);
+      if (declaredReps !== undefined && reps !== declaredReps) {
+        log.info(
+          { workCount: reps, declaredReps },
+          "lap-derived work count contradicts declared shape — falling through",
+        );
+      } else {
+        log.info({ segments: fromLaps.length }, "lap-derived segments");
+        return ensureWarmupFirst(fromLaps, activityId, t0);
+      }
+    } else {
+      log.info("lap-derivation failed — trying deterministic segmenter");
     }
-    log.info("lap-derivation failed — trying deterministic segmenter");
   }
 
   // Deterministic segmenter (speed/HR + the known/inferred structure) for the
@@ -107,15 +125,23 @@ export async function produceSegments(params: {
   // a bad split.
   const deterministic = buildSegmentsDeterministic(activityId, laps, userSets, statsStreams);
   if (deterministic && deterministic.confidence >= DETERMINISTIC_CONFIDENCE_THRESHOLD) {
-    log.info(
-      {
-        segments: deterministic.segments.length,
-        confidence: deterministic.confidence,
-        mode: deterministic.mode,
-      },
-      "deterministic segments",
-    );
-    return ensureWarmupFirst(deterministic.segments, activityId, t0);
+    const reps = workCount(deterministic.segments);
+    if (declaredReps !== undefined && reps !== declaredReps) {
+      log.info(
+        { workCount: reps, declaredReps },
+        "deterministic work count contradicts declared shape — falling through to LLM",
+      );
+    } else {
+      log.info(
+        {
+          segments: deterministic.segments.length,
+          confidence: deterministic.confidence,
+          mode: deterministic.mode,
+        },
+        "deterministic segments",
+      );
+      return ensureWarmupFirst(deterministic.segments, activityId, t0);
+    }
   }
   if (deterministic) {
     log.info(

--- a/src/agent/structure_prompt_rules.ts
+++ b/src/agent/structure_prompt_rules.ts
@@ -1,0 +1,15 @@
+/**
+ * Structure-extraction rules shared verbatim by the analyze classifier
+ * (`initial_analysis_agent.ts`) and the free-text parse agent
+ * (`parse_intervals_agent.ts`). Both emit the same `workoutSet[]` shape, so the
+ * Set/Step/rep-count rules — including the hard-won Norwegian comma-list,
+ * "N x (a,b,c)", and compound-block fixes — must live in exactly one place.
+ * Callers may append their own agent-specific rules after this block.
+ */
+export const STRUCTURE_EXTRACTION_RULES = `1. **Identify Repeating Series:** For a simple workout like **10x1000m**: create one Set with **set_reps: 1** and one Step with **reps: 10**. For a complex workout like **3x (3km + 2km + 1km)**: create one Set with **set_reps: 3** and, inside that set, three Steps (3000m, 2000m, 1000m) each with **reps: 1**.
+2. **Units:** Always convert distance to METERS and time to SECONDS.
+3. **Comma-separated values are a STEP LIST, not decimals (Norwegian list notation):** "3,2,1 km" = three Steps of 3 km, 2 km, 1 km (→ 3000m, 2000m, 1000m); "2 x 3,2,2 km" = one Set with **set_reps: 2** and three Steps (3000m, 2000m, 2000m). A comma between numbers in such a list is a SEPARATOR, never a decimal point.
+4. **"N x (a, b, c)" = N SETS of the sequence a→b→c.** Set **set_reps: N** and create ONE Step per item (reps: 1 each), so the sequence repeats a,b,c / a,b,c / … — e.g. **"5 x (3,2,1 min)"** = set_reps: 5, Steps [180s, 120s, 60s] each reps: 1; **"3x (3km + 2km + 1km)"** = set_reps: 3, Steps [3000m, 2000m, 1000m]. **Do NOT** create 3 Steps with reps: N (that wrongly groups all the a's, then all the b's, then all the c's).
+5. **Compound / sequential workouts = ONE Set PER BLOCK — capture EVERY block.** When the workout chains distinct interval blocks, emit a SEPARATE Set for each block in order, and never drop the trailing block(s). Triggers include English "X followed by Y", "X then Y", and Norwegian "X etterfulgt av Y", "X deretter Y", "X så Y", or a top-level "X + Y" joining two different rep schemes. E.g. **"4x1000m etterfulgt av 20x45/15"** = TWO Sets: Set 1 (set_reps: 1, one Step reps: 4, DISTANCE 1000m) and Set 2 (set_reps: 1, one Step reps: 20, TIME 45s work / 15s recovery). (Distinguish from rule 4's "N x (a,b,c)", which is ONE block repeated.)
+6. **Recovery placement:** Recovery between reps goes on the Step (recovery_value). A distinct longer break between sets (e.g. 5 mins between blocks of intervals) goes on the Set (set_recovery).
+7. **Ignore Warmup/Cooldown:** Only capture the "work" segments.`;

--- a/src/schema/activities.ts
+++ b/src/schema/activities.ts
@@ -54,6 +54,11 @@ export type DraftAnalysisResult = WorkoutAnalysisOutput & {
   acceptedSets?: ExpandedIntervalSet[];
   segmentsFromLaps?: boolean;
   proposedSegments?: ProposedSegmentDraft[];
+  // Provenance of the adopted structure: "text" when the title/description
+  // declared it (text authority), else "model". `declaredStructure` is what the
+  // text gate parsed, kept for observability.
+  structureSource?: "text" | "model";
+  declaredStructure?: WorkoutAnalysisOutput["structure"] | null;
 };
 
 export const activities = pgTable(

--- a/src/schema/activities.ts
+++ b/src/schema/activities.ts
@@ -19,7 +19,6 @@ import type { IIntervalsInterval } from "../types/intervals/IIntervalsActivity";
 import {
   analysisStatusEnum,
   type TargetTypeEnum,
-  type TrainingType,
   trainingTypeEnum,
   type WorkoutPartType,
 } from "./enums";
@@ -30,7 +29,6 @@ import { intervalStructures } from "./interval_structure";
 import { users } from "./users";
 
 export type IntervalsIcuPrediction = {
-  trainingType?: TrainingType;
   subType?: string | null;
   intervals?: IIntervalsInterval[];
 };

--- a/src/services/analysis_service.ts
+++ b/src/services/analysis_service.ts
@@ -14,7 +14,7 @@ import {
 import type { ExpandedIntervalSet } from "../types/ExpandedIntervalSet";
 import type { IGlobalBindings } from "../types/IRouters";
 import { progressService } from "./progress_service";
-import { needCompleteAnalysis } from "./utils";
+import { needCompleteAnalysis, resolveResumeTrainingType } from "./utils";
 
 // Thrown for user-input validation problems in the resume flow. Distinct from
 // a server-side error so the router can map it to 400.
@@ -187,8 +187,11 @@ export const resumeAnalysis = async (
   }
   const draftType = (current.draftAnalysisResult as { training_type?: TrainingType } | null)
     ?.training_type;
-  const finalTrainingType: TrainingType | null =
-    trainingType ?? current.trainingType ?? draftType ?? null;
+  const finalTrainingType = resolveResumeTrainingType(
+    trainingType,
+    draftType ?? null,
+    current.trainingType ?? null,
+  );
 
   if (!finalTrainingType) {
     throw new Error(`Cannot resume activity ${activityId} — no training type resolved`);

--- a/src/services/analysis_service.ts
+++ b/src/services/analysis_service.ts
@@ -285,23 +285,6 @@ export const resumeAnalysis = async (
   });
 };
 
-export const startAnalysisByStravaId = async (
-  db: IGlobalBindings["db"],
-  stravaAccessToken: string,
-  stravaActivityId: number,
-  userId: string,
-): Promise<void> => {
-  const result = await db.query.activities.findFirst({
-    where: eq(activities.stravaActivityId, stravaActivityId),
-    columns: { id: true },
-  });
-  if (!result) {
-    logger.error({ stravaActivityId }, "Activity not found in DB");
-    return;
-  }
-  await startAnalysis(db, stravaAccessToken, result.id, stravaActivityId, userId);
-};
-
 export const triggerAnalysisByStravaId = async (
   db: IGlobalBindings["db"],
   stravaAccessToken: string,

--- a/src/services/editor_state_service.ts
+++ b/src/services/editor_state_service.ts
@@ -94,7 +94,6 @@ export async function previewSegments(
     isIndoor: activity.indoor ?? false,
     userSets: sets,
     initialResult,
-    userNotes: "",
     trainingType,
     intervalsIcuIntervals,
     log,

--- a/src/services/segment_mapping_service.ts
+++ b/src/services/segment_mapping_service.ts
@@ -178,6 +178,22 @@ export function recomputeSegmentStats(
   }));
 }
 
+/**
+ * True when the boundaries' work count (`type === "INTERVALS"`) matches the total
+ * work-step count of `userSets`. Empty `userSets` ⇒ true (nothing to enforce).
+ * Used to detect when stale proposal boundaries diverge from the (possibly
+ * notes-reconciled) user shape, so labels aren't mapped onto the wrong rep count.
+ */
+export function boundariesMatchUserShape(
+  boundaries: SegmentBoundary[],
+  userSets: ExpandedIntervalSet[],
+): boolean {
+  const workSteps = userSets.reduce((n, s) => n + s.steps.length, 0);
+  if (workSteps === 0) return true;
+  const workBoundaries = boundaries.filter((b) => b.type === "INTERVALS").length;
+  return workBoundaries === workSteps;
+}
+
 export function toBoundaries(
   segments: { type: SegmentBoundary["type"]; setGroupIndex: number; timeSeriesEndTime: number }[],
 ): SegmentBoundary[] {

--- a/src/services/text_intent_service.ts
+++ b/src/services/text_intent_service.ts
@@ -69,6 +69,42 @@ export async function extractDeclaredStructure(
   }
 }
 
+// Partial-completion phrasing with capture groups: "8 av 10" (Norwegian), "8 of
+// 10" (English). Deliberately NOT a bare slash ("8/10") — that collides with
+// work/rest notation like "45/15".
+const N_OF_M_COMPLETION = /(\d+)\s+(?:av|of)\s+(\d+)/i;
+
+/**
+ * Deterministic "did N of M" handler — zero LLM cost. When resume-time notes say
+ * the athlete completed only the first N of M declared work steps ("klarte bare 8
+ * av 10"), truncate `userSets` to those N steps. Applies ONLY when M equals the
+ * current total work-step count and N < M (anything else is ambiguous or a no-op
+ * → null). Walks sets in order, truncating step lists and dropping sets that
+ * become empty, preserving each kept step's fields (incl. target_pace).
+ */
+export function applyPartialCompletion(
+  notes: string | null | undefined,
+  userSets: ExpandedIntervalSet[],
+): ExpandedIntervalSet[] | null {
+  if (!notes) return null;
+  const match = notes.match(N_OF_M_COMPLETION);
+  if (!match) return null;
+  const n = Number(match[1]);
+  const m = Number(match[2]);
+  const totalSteps = userSets.reduce((acc, s) => acc + s.steps.length, 0);
+  if (n <= 0 || m !== totalSteps || n >= m) return null;
+
+  const result: ExpandedIntervalSet[] = [];
+  let remaining = n;
+  for (const set of userSets) {
+    if (remaining <= 0) break;
+    const kept = set.steps.slice(0, remaining);
+    remaining -= kept.length;
+    if (kept.length > 0) result.push({ ...set, steps: kept });
+  }
+  return result;
+}
+
 function stepsEqual(a: WorkoutSet["steps"][number], b: WorkoutSet["steps"][number]): boolean {
   return (
     a.reps === b.reps &&

--- a/src/services/text_intent_service.ts
+++ b/src/services/text_intent_service.ts
@@ -1,0 +1,190 @@
+import type { z } from "zod";
+import {
+  reconcileIntervalSubtype,
+  type WorkoutAnalysisOutput,
+  type workoutSet,
+} from "../agent/initial_analysis_agent";
+import { invokeParseIntervalsAgent } from "../agent/parse_intervals_agent";
+import { logger } from "../logger";
+import type { TrainingType } from "../schema/enums";
+import type { ExpandedIntervalSet } from "../types/ExpandedIntervalSet";
+import { generateCompleteIntervalSet, needCompleteAnalysis } from "./utils";
+
+type WorkoutSet = z.infer<typeof workoutSet>;
+
+// A digit adjacent to x/× in either order ("10x1000m", "10 x 1000m", "6x6min"),
+// tolerating an opening paren after the x ("5 x (3,2,1 min)").
+const X_ADJACENT = /\d\s*[x×]\s*\(?\s*\d/i;
+// Work/rest notation ("45/15", "90/30s").
+const WORK_REST = /\d+\s*\/\s*\d+/;
+// A comma-separated number LIST followed by a unit (Norwegian list notation):
+// "3,2,1 km", "3,2,2 km" — a genuine rep sequence, not a lone distance.
+const COMMA_LIST_UNIT = /\d+\s*,\s*\d+(?:\s*,\s*\d+)*\s*(?:km|min|sek|sec|m|s)\b/i;
+// Partial-completion phrasing: "did 8 of 10", "8 av 10".
+const N_OF_M = /\d+\s+(?:of|av)\s+\d+/i;
+// Block-chain keywords that join distinct interval blocks. Only meaningful
+// alongside digits (a chained workout always carries numbers).
+const BLOCK_CHAIN = /(?:etterfulgt av|deretter|followed by|then\b)/i;
+
+/**
+ * Deterministic prefilter: could this text DECLARE a workout structure? Errs
+ * slightly toward true (a false positive costs one mini-LLM parse; a false
+ * negative silently ships the wrong structure), but generic titles ("Morning
+ * Run", "Marathon training week 12") — anything without a rep-like arrangement of
+ * numbers — must return false so they never reach the parse agent.
+ */
+export function looksStructured(text: string | null | undefined): boolean {
+  if (!text) return false;
+  const t = text.trim();
+  if (t.length === 0) return false;
+  if (X_ADJACENT.test(t)) return true;
+  if (WORK_REST.test(t)) return true;
+  if (COMMA_LIST_UNIT.test(t)) return true;
+  if (N_OF_M.test(t)) return true;
+  if (BLOCK_CHAIN.test(t) && /\d/.test(t)) return true;
+  return false;
+}
+
+/**
+ * Gate the LLM parse behind the deterministic prefilter: keep only the texts that
+ * individually look structured, and if none do, return null WITHOUT any LLM call
+ * (generic titles cost zero model spend). Otherwise join the survivors and run the
+ * parse agent (which already applies the blowup guardrail to its own output).
+ * Never throws into the caller — the analyze pipeline must not fail because the
+ * text gate hiccuped.
+ */
+export async function extractDeclaredStructure(
+  texts: (string | null | undefined)[],
+  trainingType: TrainingType | null | undefined,
+): Promise<WorkoutSet[] | null> {
+  const structured = texts.filter((t): t is string => looksStructured(t));
+  if (structured.length === 0) return null;
+  try {
+    const result = await invokeParseIntervalsAgent(structured.join("\n"), trainingType ?? null);
+    const sets = result?.sets ?? [];
+    return sets.length > 0 ? sets : null;
+  } catch (err) {
+    logger.warn({ err }, "extractDeclaredStructure: parse failed — ignoring text gate");
+    return null;
+  }
+}
+
+function stepsEqual(a: WorkoutSet["steps"][number], b: WorkoutSet["steps"][number]): boolean {
+  return (
+    a.reps === b.reps &&
+    a.work_type === b.work_type &&
+    a.work_value === b.work_value &&
+    (a.recovery_type ?? null) === (b.recovery_type ?? null) &&
+    (a.recovery_value ?? null) === (b.recovery_value ?? null)
+  );
+}
+
+function structuresEqual(
+  a: WorkoutSet[] | null | undefined,
+  b: WorkoutSet[] | null | undefined,
+): boolean {
+  const x = a ?? [];
+  const y = b ?? [];
+  if (x.length !== y.length) return false;
+  for (let i = 0; i < x.length; i++) {
+    if (x[i].set_reps !== y[i].set_reps) return false;
+    if ((x[i].set_recovery ?? null) !== (y[i].set_recovery ?? null)) return false;
+    if (x[i].steps.length !== y[i].steps.length) return false;
+    for (let j = 0; j < x[i].steps.length; j++) {
+      if (!stepsEqual(x[i].steps[j], y[i].steps[j])) return false;
+    }
+  }
+  return true;
+}
+
+/** Same hard gate as the classifier: any rep >= 120s or >= 800m ⇒ LONG. */
+function classifyFromDeclared(declared: WorkoutSet[]): "SHORT_INTERVALS" | "LONG_INTERVALS" {
+  for (const set of declared) {
+    for (const step of set.steps) {
+      if (step.work_type === "DISTANCE" ? step.work_value >= 800 : step.work_value >= 120) {
+        return "LONG_INTERVALS";
+      }
+    }
+  }
+  return "SHORT_INTERVALS";
+}
+
+/**
+ * Text wins on SHAPE. Adopt the declared structure over the model's: declared
+ * set count, set_reps, per-step reps/work_type/work_value are authoritative. When
+ * the model and declared align positionally (same set count and per-set step
+ * count), carry the model's recovery values into steps the declared shape leaves
+ * unspecified (declared recovery wins when present); otherwise take the declared
+ * sets verbatim. Then fix training_type: interval subtypes re-run the existing
+ * gate; a type that doesn't need complete analysis (e.g. the misclassify-EASY
+ * failure mode) is reclassified deterministically from the declared reps; other
+ * interval-family types keep their type.
+ */
+export function reconcileStructureTowardDeclared(
+  model: WorkoutAnalysisOutput,
+  declared: WorkoutSet[],
+): { result: WorkoutAnalysisOutput; changed: boolean } {
+  const modelStructure = model.structure ?? [];
+  const aligned =
+    modelStructure.length === declared.length &&
+    declared.every((set, i) => set.steps.length === modelStructure[i].steps.length);
+
+  const newStructure: WorkoutSet[] = aligned
+    ? declared.map((set, i) => {
+        const modelSet = modelStructure[i];
+        return {
+          set_reps: set.set_reps,
+          set_recovery: set.set_recovery ?? modelSet.set_recovery,
+          steps: set.steps.map((step, j) => {
+            const modelStep = modelSet.steps[j];
+            return {
+              reps: step.reps,
+              work_type: step.work_type,
+              work_value: step.work_value,
+              recovery_type: step.recovery_type ?? modelStep.recovery_type,
+              recovery_value: step.recovery_value ?? modelStep.recovery_value,
+            };
+          }),
+        };
+      })
+    : declared;
+
+  let trainingType = model.training_type;
+  if (trainingType === "SHORT_INTERVALS" || trainingType === "LONG_INTERVALS") {
+    trainingType = reconcileIntervalSubtype({
+      ...model,
+      structure: newStructure,
+    }).training_type;
+  } else if (!needCompleteAnalysis(trainingType)) {
+    trainingType = classifyFromDeclared(newStructure);
+  }
+
+  const changed =
+    trainingType !== model.training_type || !structuresEqual(modelStructure, newStructure);
+
+  return {
+    result: { ...model, structure: newStructure, training_type: trainingType },
+    changed,
+  };
+}
+
+/**
+ * Rebuild the user's expanded set list from a notes-declared structure, carrying
+ * each previous work step's target_pace over positionally (flatten both to step
+ * lists, copy by index while an index exists; extra steps keep null pace).
+ */
+export function rebuildSetsWithDeclaredPaces(
+  declared: WorkoutSet[],
+  previous: ExpandedIntervalSet[],
+): ExpandedIntervalSet[] {
+  const prevPaces = previous.flatMap((s) => s.steps.map((st) => st.target_pace ?? null));
+  const rebuilt = generateCompleteIntervalSet(declared) as ExpandedIntervalSet[];
+  let idx = 0;
+  for (const set of rebuilt) {
+    for (const step of set.steps) {
+      step.target_pace = idx < prevPaces.length ? prevPaces[idx] : null;
+      idx++;
+    }
+  }
+  return rebuilt;
+}

--- a/src/services/text_intent_service.ts
+++ b/src/services/text_intent_service.ts
@@ -129,20 +129,25 @@ export function reconcileStructureTowardDeclared(
     modelStructure.length === declared.length &&
     declared.every((set, i) => set.steps.length === modelStructure[i].steps.length);
 
+  // The parse agent emits recovery_value 0 / set_recovery 0 (not null) when the
+  // text says nothing about recovery, so 0 means "unspecified" — keep the model's
+  // measured recovery in that case, and take the pair together so a declared
+  // value never merges with a model type (or vice versa).
   const newStructure: WorkoutSet[] = aligned
     ? declared.map((set, i) => {
         const modelSet = modelStructure[i];
         return {
           set_reps: set.set_reps,
-          set_recovery: set.set_recovery ?? modelSet.set_recovery,
+          set_recovery: set.set_recovery || modelSet.set_recovery,
           steps: set.steps.map((step, j) => {
             const modelStep = modelSet.steps[j];
+            const declaredRecovery = (step.recovery_value ?? 0) > 0;
             return {
               reps: step.reps,
               work_type: step.work_type,
               work_value: step.work_value,
-              recovery_type: step.recovery_type ?? modelStep.recovery_type,
-              recovery_value: step.recovery_value ?? modelStep.recovery_value,
+              recovery_type: declaredRecovery ? step.recovery_type : modelStep.recovery_type,
+              recovery_value: declaredRecovery ? step.recovery_value : modelStep.recovery_value,
             };
           }),
         };

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -26,6 +26,18 @@ export const ANALYZED_SPORT_TYPES = new Set<string>([
 export function shouldAnalyze(sportType: string): boolean {
   return ANALYZED_SPORT_TYPES.has(sportType);
 }
+// Precedence on resume: an explicit user choice always wins; otherwise the FRESH
+// draft's type (written this run) beats the activities column, which only holds
+// the PREVIOUS completed run's type and would silently shadow a force
+// re-analysis. The column is the legacy fallback for rows without a draft.
+export function resolveResumeTrainingType(
+  userType: TrainingType | null,
+  draftType: TrainingType | null,
+  columnType: TrainingType | null,
+): TrainingType | null {
+  return userType ?? draftType ?? columnType ?? null;
+}
+
 export function needCompleteAnalysis(trainingType: TrainingType): boolean {
   const trainingTypes: TrainingType[] = [
     "SHORT_INTERVALS",

--- a/tests/parse_sets_blowup_reconcile.test.ts
+++ b/tests/parse_sets_blowup_reconcile.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { reconcileSetsBlowup, workoutSet } from "../src/agent/initial_analysis_agent";
+import type { z } from "zod";
+
+// Sets-level guardrail applied to parse-agent output (D4): collapse the Cartesian
+// rep-count blowup where the model emits N steps that EACH carry reps:N. Same core
+// as reconcileStructureBlowup, but operating on a bare workoutSet[] so the parse
+// endpoint, the coach parse_workout tool, and the text gate all get scrubbed output.
+type Set = z.infer<typeof workoutSet>;
+const blowup = (values: number[], work_type: "DISTANCE" | "TIME" = "DISTANCE"): Set[] => [
+  {
+    set_reps: 1,
+    steps: values.map((v) => ({ reps: values.length, work_type, work_value: v })),
+  },
+];
+const totalReps = (sets: Set[]): number =>
+  sets.reduce(
+    (n, s) => n + (s.set_reps ?? 1) * s.steps.reduce((a, st) => a + (st.reps ?? 1), 0),
+    0,
+  );
+
+describe("reconcileSetsBlowup", () => {
+  it("collapses N (>=3) identical-reps steps to one step at the MEDIAN work_value", () => {
+    const out = reconcileSetsBlowup(blowup([936, 906, 693, 954, 991, 959, 988, 1065, 1221]));
+    expect(totalReps(out)).toBe(9);
+    expect(out[0].steps).toHaveLength(1);
+    expect(out[0].steps[0].reps).toBe(9);
+    // median ~959m (>=800 keeps LONG); the 693m min must not win.
+    expect(out[0].steps[0].work_value).toBeGreaterThanOrEqual(800);
+  });
+  it("leaves a genuine sequence (steps with reps:1) untouched", () => {
+    const seq: Set[] = [
+      {
+        set_reps: 3,
+        steps: [
+          { reps: 1, work_type: "DISTANCE", work_value: 3000 },
+          { reps: 1, work_type: "DISTANCE", work_value: 2000 },
+          { reps: 1, work_type: "DISTANCE", work_value: 1000 },
+        ],
+      },
+    ];
+    expect(reconcileSetsBlowup(seq)).toEqual(seq);
+  });
+  it("passes empty sets through unchanged", () => {
+    const empty: Set[] = [];
+    const out = reconcileSetsBlowup(empty);
+    expect(out).toEqual([]);
+    expect(out).toBe(empty);
+  });
+});

--- a/tests/pipeline_text_authority.test.ts
+++ b/tests/pipeline_text_authority.test.ts
@@ -1,0 +1,274 @@
+import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { Command } from "@langchain/langgraph";
+import { eq } from "drizzle-orm";
+import { buildAnalysisGraph, resetAnalysisThread } from "../src/agent/analysis_graph";
+import * as eventAgent from "../src/agent/event_detection_agent";
+import * as fullAnalysis from "../src/agent/full_analysis_agent";
+import type { SegmentPlanOutput } from "../src/agent/full_analysis_agent";
+import * as initialAgent from "../src/agent/initial_analysis_agent";
+import type { WorkoutAnalysisOutput } from "../src/agent/initial_analysis_agent";
+import * as parseAgent from "../src/agent/parse_intervals_agent";
+import { activities } from "../src/schema";
+import { intervalSegments } from "../src/schema/interval_segments";
+import type { DraftAnalysisResult } from "../src/schema/activities";
+import * as deterministic from "../src/services/deterministic_segmenter";
+import * as paceService from "../src/services/pace_service";
+import { stravaApiService } from "../src/services/strava_api_service";
+import { generateCompleteIntervalSet } from "../src/services/utils";
+import type { ExpandedIntervalSet } from "../src/types/ExpandedIntervalSet";
+import type { StreamSet } from "../src/types/strava/IStream";
+import { createTestUser, deleteTestUser, getDb } from "./helpers/db";
+import { insertActivity } from "./helpers/fixtures";
+
+// End-to-end drive of the REAL compiled analysis graph (real PostgresSaver
+// checkpointer, real nodes, real reconciliation + declaredReps enforcement).
+// Only the external boundaries are stubbed: the classifier LLM (deliberately
+// WRONG — EASY / 8 reps), the parse agent (text → sets), the segmentation LLM
+// (builds a plan straight from its userSets so the work count follows the
+// authoritative shape), the event agent (no events), the deterministic
+// segmenter (forced off so the LLM rung is always reached), the pace fill, and
+// the Strava fetch. The scenario is the flagship failure mode this project
+// fixes: a colloquial "10x1000m" title the classifier collapses to EASY.
+
+const SAMPLES = 3000; // 1s samples over ~50 min
+
+function buildStreams(): StreamSet {
+  const time = Array.from({ length: SAMPLES }, (_, i) => i);
+  const distance = Array.from({ length: SAMPLES }, (_, i) => i * 3); // ~3 m/s
+  const velocity = Array.from({ length: SAMPLES }, () => 3);
+  return {
+    time: { data: time },
+    distance: { data: distance },
+    velocity_smooth: { data: velocity },
+  };
+}
+
+const declaredSet = (reps: number) => ({
+  set_reps: 1,
+  set_recovery: 0,
+  steps: [
+    {
+      reps,
+      work_type: "DISTANCE" as const,
+      work_value: 1000,
+      recovery_type: null,
+      recovery_value: 0,
+    },
+  ],
+});
+
+// The segmentation-LLM stub: WARMUP, then per work step an INTERVALS + REST,
+// with plausible times inside the stream range. Work count == total steps.
+function buildPlanFromGroups(groups: ExpandedIntervalSet[]): SegmentPlanOutput {
+  const segments: SegmentPlanOutput["segments"] = [];
+  let t = 0;
+  segments.push({ type: "WARMUP", start_time: t, end_time: t + 200, target_type: "custom", target_value: 0 });
+  t += 200;
+  let groupIndex = 0;
+  for (const group of groups) {
+    groupIndex += 1;
+    for (const step of group.steps) {
+      segments.push({
+        type: "INTERVALS",
+        start_time: t,
+        end_time: t + 100,
+        set_group_index: groupIndex,
+        target_type: step.work_type === "DISTANCE" ? "distance" : "time",
+        target_value: step.work_value,
+      });
+      t += 100;
+      segments.push({
+        type: "REST",
+        start_time: t,
+        end_time: t + 60,
+        set_group_index: groupIndex,
+        target_type: "time",
+        target_value: 60,
+      });
+      t += 60;
+    }
+  }
+  return { segments };
+}
+
+function totalReps(structure: WorkoutAnalysisOutput["structure"]): number {
+  return (structure ?? []).reduce(
+    (n, s) => n + (s.set_reps ?? 1) * s.steps.reduce((a, st) => a + (st.reps ?? 1), 0),
+    0,
+  );
+}
+
+describe("analysis graph — text as structure authority (end-to-end)", () => {
+  let userId: string;
+  let activityId: number;
+  let stravaActivityId: number;
+
+  const spies: { mockRestore: () => void }[] = [];
+
+  beforeAll(async () => {
+    const user = await createTestUser({ intervals: false, processHeartRate: false });
+    userId = user.id;
+    const seeded = await insertActivity(userId, {
+      title: "10x1000m",
+      description: "-",
+      analysisStatus: "pending",
+      trainingType: null,
+      indoor: false,
+    });
+    activityId = seeded.id;
+    stravaActivityId = seeded.stravaActivityId;
+
+    const streams = buildStreams();
+
+    // ─── Strava boundary ────────────────────────────────────────────────────
+    spies.push(
+      spyOn(stravaApiService, "getActivity").mockResolvedValue({
+        id: stravaActivityId,
+        name: "auto-name",
+        description: null,
+        trainer: false,
+        start_date_local: new Date().toISOString(),
+        type: "Run",
+        total_elevation_gain: 0,
+      } as never),
+      spyOn(stravaApiService, "getActivityStreams").mockResolvedValue(streams as never),
+      spyOn(stravaApiService, "getActivityLaps").mockResolvedValue([] as never),
+    );
+
+    // ─── Classifier LLM (deliberately WRONG: EASY, 8×1000m) ─────────────────
+    spies.push(
+      spyOn(initialAgent, "invokeActivityAnalysisAgent").mockResolvedValue({
+        classification_reasoning: "stub",
+        training_type: "EASY",
+        confidence_score: 0.9,
+        intervals_description: null,
+        structure: [
+          {
+            set_reps: 1,
+            set_recovery: 300,
+            steps: [
+              {
+                reps: 8,
+                work_type: "DISTANCE",
+                work_value: 1000,
+                recovery_type: "TIME",
+                recovery_value: 90,
+              },
+            ],
+          },
+        ],
+      } as never),
+    );
+
+    // ─── Parse agent: title-like → 10, notes with "8 av 10" → 8 ─────────────
+    spies.push(
+      spyOn(parseAgent, "invokeParseIntervalsAgent").mockImplementation(async (text: string) => {
+        if (/\b8\s*av\s*10\b|\bav\s+10\b|bare\s*8/i.test(text)) return { sets: [declaredSet(8)] };
+        if (/\d\s*[x×]\s*1000|1000\s*m/i.test(text)) return { sets: [declaredSet(10)] };
+        return { sets: [] };
+      }),
+    );
+
+    // ─── Pace fill: keep the full expanded structure (setup stub returns []) ──
+    spies.push(
+      spyOn(paceService, "getProposedPaceForStructure").mockImplementation(
+        async (_db: unknown, _uid: unknown, structure: never) =>
+          generateCompleteIntervalSet(structure) as never,
+      ),
+    );
+
+    // ─── Deterministic segmenter off → LLM rung always reached ──────────────
+    spies.push(spyOn(deterministic, "buildSegmentsDeterministic").mockReturnValue(null));
+
+    // ─── Segmentation LLM builds a plan straight from its userSets shape ─────
+    spies.push(
+      spyOn(fullAnalysis, "invokeCompleteActivityAnalysisAgent").mockImplementation(
+        async (
+          _streams: unknown,
+          _comment: unknown,
+          _tt: unknown,
+          _laps: unknown,
+          _init: unknown,
+          groups: ExpandedIntervalSet[],
+        ) => buildPlanFromGroups(groups) as never,
+      ),
+    );
+
+    // ─── Event detection: no events ─────────────────────────────────────────
+    spies.push(
+      spyOn(eventAgent, "invokeEventDetectionAgent").mockResolvedValue({ events: [] } as never),
+    );
+
+    await resetAnalysisThread(activityId);
+  });
+
+  afterAll(async () => {
+    for (const s of spies) s.mockRestore();
+    await resetAnalysisThread(activityId).catch(() => {});
+    // Cascades activity + interval_segments rows. The global interval_structures
+    // dedupe row is intentionally left (shared/ephemeral in the disposable DB).
+    await deleteTestUser(userId);
+  });
+
+  const config = () => ({
+    configurable: {
+      thread_id: String(activityId),
+      db: getDb(),
+      stravaAccessToken: "test-strava-token",
+      intervalsAthleteId: null,
+    },
+  });
+
+  it("start → interrupt: text overrides EASY, structure is 10 reps of LONG_INTERVALS", async () => {
+    const graph = await buildAnalysisGraph();
+    await graph.invoke({ activityId, stravaActivityId, userId }, config());
+
+    const db = getDb();
+    const row = await db.query.activities.findFirst({
+      where: eq(activities.id, activityId),
+      columns: { analysisStatus: true, draftAnalysisResult: true },
+    });
+    expect(row).toBeTruthy();
+    expect(row?.analysisStatus).toBe("initial");
+
+    const draft = row?.draftAnalysisResult as DraftAnalysisResult;
+    expect(draft.structureSource).toBe("text");
+    expect(draft.declaredStructure).toBeTruthy();
+    expect(draft.training_type).toBe("LONG_INTERVALS");
+    expect(totalReps(draft.structure)).toBe(10);
+
+    const proposedIntervals = (draft.proposedSegments ?? []).filter((s) => s.type === "INTERVALS");
+    expect(proposedIntervals).toHaveLength(10);
+  });
+
+  it("resume with notes '8 av 10': completes with exactly 8 INTERVALS segments", async () => {
+    const graph = await buildAnalysisGraph();
+    await graph.invoke(
+      new Command({
+        resume: {
+          notes: "klarte bare 8 av 10",
+          sets: [],
+          trainingType: null,
+          feeling: 3,
+          editedSegments: [],
+        },
+      }),
+      config(),
+    );
+
+    const db = getDb();
+    const row = await db.query.activities.findFirst({
+      where: eq(activities.id, activityId),
+      columns: { analysisStatus: true, intervalStructureId: true },
+    });
+    expect(row?.analysisStatus).toBe("completed");
+    expect(row?.intervalStructureId).toBeTruthy();
+
+    const segs = await db
+      .select()
+      .from(intervalSegments)
+      .where(eq(intervalSegments.activityId, activityId));
+    const intervalsRows = segs.filter((s) => s.type === "INTERVALS");
+    expect(intervalsRows).toHaveLength(8);
+  });
+});

--- a/tests/pipeline_text_authority.test.ts
+++ b/tests/pipeline_text_authority.test.ts
@@ -160,10 +160,10 @@ describe("analysis graph — text as structure authority (end-to-end)", () => {
       } as never),
     );
 
-    // ─── Parse agent: title-like → 10, notes with "8 av 10" → 8 ─────────────
+    // ─── Parse agent: title-like → 10; "8 av 10" notes name no distances, so the
+    // real agent returns empty (the 8 is carried by applyPartialCompletion) ─────
     spies.push(
       spyOn(parseAgent, "invokeParseIntervalsAgent").mockImplementation(async (text: string) => {
-        if (/\b8\s*av\s*10\b|\bav\s+10\b|bare\s*8/i.test(text)) return { sets: [declaredSet(8)] };
         if (/\d\s*[x×]\s*1000|1000\s*m/i.test(text)) return { sets: [declaredSet(10)] };
         return { sets: [] };
       }),

--- a/tests/reconcile_toward_declared.test.ts
+++ b/tests/reconcile_toward_declared.test.ts
@@ -67,6 +67,32 @@ describe("reconcileStructureTowardDeclared", () => {
     expect(changed).toBe(true);
   });
 
+  it("treats declared recovery_value 0 / set_recovery 0 as unspecified (real gpt-4o-mini shape)", () => {
+    const model = mk("LONG_INTERVALS", [
+      { ...dist(8, 1000, { recovery_type: "TIME", recovery_value: 90 }), set_recovery: 300 },
+    ]);
+    const { result } = reconcileStructureTowardDeclared(model, [
+      { ...dist(10, 1000, { recovery_type: null, recovery_value: 0 }), set_recovery: 0 },
+    ]);
+    const set = (result.structure ?? [])[0];
+    expect(set.steps[0].reps).toBe(10);
+    expect(set.steps[0].recovery_value).toBe(90); // 0 = unspecified → model recovery kept
+    expect(set.steps[0].recovery_type).toBe("TIME"); // type follows value as a pair
+    expect(set.set_recovery).toBe(300);
+  });
+
+  it("declared non-zero recovery wins as a pair over the model's", () => {
+    const model = mk("LONG_INTERVALS", [
+      dist(10, 1000, { recovery_type: "TIME", recovery_value: 90 }),
+    ]);
+    const { result } = reconcileStructureTowardDeclared(model, [
+      dist(10, 1000, { recovery_type: "DISTANCE", recovery_value: 200 }),
+    ]);
+    const step = (result.structure ?? [])[0].steps[0];
+    expect(step.recovery_type).toBe("DISTANCE");
+    expect(step.recovery_value).toBe(200);
+  });
+
   it("uses declared sets verbatim when shapes don't align", () => {
     const model = mk("LONG_INTERVALS", [
       {

--- a/tests/reconcile_toward_declared.test.ts
+++ b/tests/reconcile_toward_declared.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import type { WorkoutAnalysisOutput, workoutSet } from "../src/agent/initial_analysis_agent";
+import {
+  rebuildSetsWithDeclaredPaces,
+  reconcileStructureTowardDeclared,
+} from "../src/services/text_intent_service";
+import type { ExpandedIntervalSet } from "../src/types/ExpandedIntervalSet";
+import type { z } from "zod";
+
+type Set = z.infer<typeof workoutSet>;
+
+const mk = (training_type: string, structure: Set[] | null): WorkoutAnalysisOutput =>
+  ({
+    classification_reasoning: "x",
+    training_type,
+    confidence_score: 0.9,
+    structure,
+  }) as unknown as WorkoutAnalysisOutput;
+
+const dist = (reps: number, work_value: number, extra: Partial<Set["steps"][number]> = {}): Set => ({
+  set_reps: 1,
+  steps: [{ reps, work_type: "DISTANCE", work_value, ...extra }],
+});
+const time = (reps: number, work_value: number): Set => ({
+  set_reps: 1,
+  steps: [{ reps, work_type: "TIME", work_value }],
+});
+const totalReps = (structure: WorkoutAnalysisOutput["structure"]): number =>
+  (structure ?? []).reduce(
+    (n, s) => n + (s.set_reps ?? 1) * s.steps.reduce((a, st) => a + (st.reps ?? 1), 0),
+    0,
+  );
+
+describe("reconcileStructureTowardDeclared", () => {
+  it("adopts the declared rep count (declared 10×1000m over model 8×1000m)", () => {
+    const { result, changed } = reconcileStructureTowardDeclared(
+      mk("LONG_INTERVALS", [dist(8, 1000)]),
+      [dist(10, 1000)],
+    );
+    expect(totalReps(result.structure)).toBe(10);
+    expect(changed).toBe(true);
+  });
+
+  it("reclassifies a misclassified EASY toward LONG_INTERVALS from the declared reps", () => {
+    const { result, changed } = reconcileStructureTowardDeclared(mk("EASY", null), [dist(10, 1000)]);
+    expect(result.training_type).toBe("LONG_INTERVALS");
+    expect(totalReps(result.structure)).toBe(10);
+    expect(changed).toBe(true);
+  });
+
+  it("flips SHORT_INTERVALS to LONG via the subtype gate (declared 6×6min)", () => {
+    const { result } = reconcileStructureTowardDeclared(mk("SHORT_INTERVALS", [time(20, 45)]), [
+      time(6, 360),
+    ]);
+    expect(result.training_type).toBe("LONG_INTERVALS");
+  });
+
+  it("keeps model recovery values where declared shape doesn't specify them (aligned)", () => {
+    const model = mk("LONG_INTERVALS", [
+      dist(5, 1000, { recovery_type: "TIME", recovery_value: 90 }),
+    ]);
+    const { result, changed } = reconcileStructureTowardDeclared(model, [dist(6, 1000)]);
+    const step = (result.structure ?? [])[0].steps[0];
+    expect(step.reps).toBe(6); // declared work wins
+    expect(step.recovery_value).toBe(90); // model recovery carried over
+    expect(step.recovery_type).toBe("TIME");
+    expect(changed).toBe(true);
+  });
+
+  it("uses declared sets verbatim when shapes don't align", () => {
+    const model = mk("LONG_INTERVALS", [
+      {
+        set_reps: 1,
+        steps: [
+          { reps: 4, work_type: "DISTANCE", work_value: 1000 },
+          { reps: 20, work_type: "TIME", work_value: 45 },
+        ],
+      },
+    ]);
+    const declared: Set[] = [dist(4, 1000), time(20, 45)];
+    const { result, changed } = reconcileStructureTowardDeclared(model, declared);
+    expect(result.structure).toEqual(declared);
+    expect(changed).toBe(true);
+  });
+
+  it("reports changed:false when the declared shape equals the model's", () => {
+    const same = [dist(5, 1000)];
+    const { result, changed } = reconcileStructureTowardDeclared(
+      mk("LONG_INTERVALS", [dist(5, 1000)]),
+      same,
+    );
+    expect(changed).toBe(false);
+    expect(result.training_type).toBe("LONG_INTERVALS");
+  });
+});
+
+describe("rebuildSetsWithDeclaredPaces", () => {
+  const prevWithPaces = (n: number): ExpandedIntervalSet[] => [
+    {
+      set_recovery: null,
+      steps: Array.from({ length: n }, (_, i) => ({
+        work_type: "DISTANCE" as const,
+        work_value: 1000,
+        recovery_type: null,
+        recovery_value: null,
+        target_pace: i + 1, // 1..n, distinct per step
+      })),
+    },
+  ];
+  const flatPaces = (sets: ExpandedIntervalSet[]): (number | null)[] =>
+    sets.flatMap((s) => s.steps.map((st) => st.target_pace ?? null));
+
+  it("carries the first N paces when the declared structure shrinks (8 vs 10)", () => {
+    const out = rebuildSetsWithDeclaredPaces(
+      [{ set_reps: 1, steps: [{ reps: 8, work_type: "DISTANCE", work_value: 1000 }] }],
+      prevWithPaces(10),
+    );
+    const paces = flatPaces(out);
+    expect(paces).toHaveLength(8);
+    expect(paces).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("gives extra steps null pace when the declared structure grows (12 vs 10)", () => {
+    const out = rebuildSetsWithDeclaredPaces(
+      [{ set_reps: 1, steps: [{ reps: 12, work_type: "DISTANCE", work_value: 1000 }] }],
+      prevWithPaces(10),
+    );
+    const paces = flatPaces(out);
+    expect(paces).toHaveLength(12);
+    expect(paces.slice(0, 10)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(paces.slice(10)).toEqual([null, null]);
+  });
+});

--- a/tests/reconcile_toward_declared.test.ts
+++ b/tests/reconcile_toward_declared.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { WorkoutAnalysisOutput, workoutSet } from "../src/agent/initial_analysis_agent";
 import {
+  applyPartialCompletion,
   rebuildSetsWithDeclaredPaces,
   reconcileStructureTowardDeclared,
 } from "../src/services/text_intent_service";
@@ -155,5 +156,61 @@ describe("rebuildSetsWithDeclaredPaces", () => {
     expect(paces).toHaveLength(12);
     expect(paces.slice(0, 10)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     expect(paces.slice(10)).toEqual([null, null]);
+  });
+});
+
+describe("applyPartialCompletion", () => {
+  const step = (target_pace: number | null) => ({
+    work_type: "DISTANCE" as const,
+    work_value: 1000,
+    recovery_type: null,
+    recovery_value: null,
+    target_pace,
+  });
+  // One set with n distinct-paced work steps (1..n).
+  const oneSet = (n: number): ExpandedIntervalSet[] => [
+    { set_recovery: null, steps: Array.from({ length: n }, (_, i) => step(i + 1)) },
+  ];
+  const flatPaces = (sets: ExpandedIntervalSet[]): (number | null)[] =>
+    sets.flatMap((s) => s.steps.map((st) => st.target_pace ?? null));
+
+  it("truncates to N steps for Norwegian 'klarte bare 8 av 10', preserving paces", () => {
+    const out = applyPartialCompletion("klarte bare 8 av 10", oneSet(10));
+    expect(out).not.toBeNull();
+    expect(flatPaces(out ?? [])).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("handles the English 'did 8 of 10' form", () => {
+    const out = applyPartialCompletion("did 8 of 10", oneSet(10));
+    expect(flatPaces(out ?? [])).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("returns null when M does not match the total work-step count ('8 av 12', 10 steps)", () => {
+    expect(applyPartialCompletion("8 av 12", oneSet(10))).toBeNull();
+  });
+
+  it("returns null when N >= M (nothing was skipped)", () => {
+    expect(applyPartialCompletion("10 av 10", oneSet(10))).toBeNull();
+  });
+
+  it("returns null when no completion pattern is present", () => {
+    expect(applyPartialCompletion("felt sterk hele veien", oneSet(10))).toBeNull();
+  });
+
+  it("does NOT treat work/rest '45/15' as a completion count", () => {
+    expect(applyPartialCompletion("45/15", oneSet(10))).toBeNull();
+  });
+
+  it("preserves set grouping across sets (2×5 steps, '8 av 10' → 5 + 3)", () => {
+    const grouped: ExpandedIntervalSet[] = [
+      { set_recovery: 300, steps: Array.from({ length: 5 }, (_, i) => step(i + 1)) },
+      { set_recovery: 300, steps: Array.from({ length: 5 }, (_, i) => step(i + 6)) },
+    ];
+    const out = applyPartialCompletion("8 av 10", grouped);
+    expect(out).not.toBeNull();
+    expect(out).toHaveLength(2);
+    expect(out?.[0].steps).toHaveLength(5);
+    expect(out?.[1].steps).toHaveLength(3);
+    expect(flatPaces(out ?? [])).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 });

--- a/tests/resolve_resume_training_type.test.ts
+++ b/tests/resolve_resume_training_type.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { resolveResumeTrainingType } from "../src/services/utils";
+
+describe("resolveResumeTrainingType", () => {
+  it("user-submitted type always wins", () => {
+    expect(
+      resolveResumeTrainingType("LONG_INTERVALS", "SHORT_INTERVALS", "EASY"),
+    ).toBe("LONG_INTERVALS");
+  });
+
+  it("fresh draft beats a stale column on force re-analysis (user null)", () => {
+    expect(resolveResumeTrainingType(null, "LONG_INTERVALS", "SHORT_INTERVALS")).toBe(
+      "LONG_INTERVALS",
+    );
+  });
+
+  it("uses the column only when user and draft are both null (legacy fallback)", () => {
+    expect(resolveResumeTrainingType(null, null, "EASY")).toBe("EASY");
+  });
+
+  it("returns null when all three are null", () => {
+    expect(resolveResumeTrainingType(null, null, null)).toBeNull();
+  });
+});

--- a/tests/segment_mapping.test.ts
+++ b/tests/segment_mapping.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  boundariesMatchUserShape,
   type FullSegmentSpec,
   mapBoundariesToSegments,
   recomputeSegmentStats,
@@ -7,7 +8,10 @@ import {
   toBoundaries,
 } from "../src/services/segment_mapping_service";
 import type { SegmentBoundary } from "../src/agent/graph_state";
-import type { ExpandedIntervalSet } from "../src/types/ExpandedIntervalSet";
+import type {
+  ExpandedIntervalSet,
+  ExpandedIntervalStep,
+} from "../src/types/ExpandedIntervalSet";
 
 function streams() {
   return {
@@ -226,5 +230,37 @@ describe("toBoundaries", () => {
     }[] = [{ type: "WARMUP", setGroupIndex: 0, timeSeriesEndTime: 20, actualDistance: 60 }];
     const out = toBoundaries(full);
     expect(out).toEqual([{ type: "WARMUP", setGroupIndex: 0, timeSeriesEndTime: 20 }]);
+  });
+});
+
+describe("boundariesMatchUserShape", () => {
+  const step: ExpandedIntervalStep = {
+    work_type: "DISTANCE",
+    work_value: 400,
+    recovery_type: "TIME",
+    recovery_value: 60,
+    target_pace: 3.5,
+  };
+  const setWith = (n: number): ExpandedIntervalSet => ({ steps: Array.from({ length: n }, () => step) });
+  const workBoundaries = (n: number): SegmentBoundary[] => [
+    { type: "WARMUP", setGroupIndex: 0, timeSeriesEndTime: 10 },
+    ...Array.from({ length: n }, (_, i) => ({
+      type: "INTERVALS" as const,
+      setGroupIndex: 1,
+      timeSeriesEndTime: 20 + i * 10,
+    })),
+    { type: "COOL_DOWN", setGroupIndex: 0, timeSeriesEndTime: 20 + n * 10 },
+  ];
+
+  it("matching work counts → true", () => {
+    expect(boundariesMatchUserShape(workBoundaries(8), [setWith(8)])).toBe(true);
+  });
+
+  it("proposal 10 work boundaries vs 8 user steps → false", () => {
+    expect(boundariesMatchUserShape(workBoundaries(10), [setWith(8)])).toBe(false);
+  });
+
+  it("empty userSets → true (nothing to enforce)", () => {
+    expect(boundariesMatchUserShape(workBoundaries(10), [])).toBe(true);
   });
 });

--- a/tests/segment_production_declared_reps.test.ts
+++ b/tests/segment_production_declared_reps.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as fullAnalysis from "../src/agent/full_analysis_agent";
+import { produceSegments } from "../src/agent/segment_production";
+import { logger } from "../src/logger";
+import type { InsertIntervalSegment } from "../src/schema/interval_segments";
+import * as deterministic from "../src/services/deterministic_segmenter";
+import * as lapDeriv from "../src/services/lap_derivation_service";
+
+// Shape enforcement (item 4): when a text/notes-declared rep count is passed as
+// `declaredReps`, a rung whose produced work count contradicts it must fall
+// through to the next rung instead of shipping the wrong count. With declaredReps
+// undefined the behavior is unchanged.
+
+const interval = (i: number): InsertIntervalSegment => ({
+  activityId: 1,
+  segmentIndex: i,
+  setGroupIndex: 1,
+  type: "INTERVALS",
+  targetType: "distance",
+  targetValue: 1000,
+  targetPace: null,
+  timeSeriesEndTime: (i + 1) * 100,
+  actualDistance: 1000,
+  actualDuration: 100,
+  avgHeartRate: null,
+});
+const intervals = (n: number): InsertIntervalSegment[] =>
+  Array.from({ length: n }, (_, i) => interval(i));
+const workCount = (segs: InsertIntervalSegment[]): number =>
+  segs.filter((s) => s.type === "INTERVALS").length;
+
+const statsStreams = {
+  time: { data: [0, 100, 200, 300, 400, 500] },
+  distance: { data: [0, 1000, 2000, 3000, 4000, 5000] },
+} as Parameters<typeof produceSegments>[0]["statsStreams"];
+
+const base = {
+  activityId: 1,
+  statsStreams,
+  streams: statsStreams as never,
+  isIndoor: false,
+  userSets: [],
+  initialResult: null,
+  userNotes: "",
+  trainingType: "LONG_INTERVALS" as const,
+  intervalsIcuIntervals: null,
+  log: logger.child({ test: "declaredReps" }),
+  tag: "[test]",
+};
+
+describe("produceSegments declaredReps enforcement", () => {
+  afterEach(() => {
+    lapSpyMatch?.mockRestore();
+    lapSpyBuild?.mockRestore();
+    detSpy?.mockRestore();
+    llmSpy?.mockRestore();
+    lapSpyMatch = lapSpyBuild = detSpy = llmSpy = undefined;
+  });
+
+  let lapSpyMatch: ReturnType<typeof spyOn> | undefined;
+  let lapSpyBuild: ReturnType<typeof spyOn> | undefined;
+  let detSpy: ReturnType<typeof spyOn> | undefined;
+  let llmSpy: ReturnType<typeof spyOn> | undefined;
+
+  it("returns the lap rung when declaredReps is undefined (unchanged behavior)", async () => {
+    lapSpyMatch = spyOn(lapDeriv, "structureShapeMatches").mockReturnValue(true);
+    lapSpyBuild = spyOn(lapDeriv, "buildSegmentsFromLaps").mockReturnValue(intervals(3));
+    detSpy = spyOn(deterministic, "buildSegmentsDeterministic");
+
+    const out = await produceSegments({ ...base, laps: [{}, {}] as never });
+
+    expect(workCount(out)).toBe(3);
+    expect(detSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("falls through the lap rung when its work count contradicts declaredReps", async () => {
+    lapSpyMatch = spyOn(lapDeriv, "structureShapeMatches").mockReturnValue(true);
+    lapSpyBuild = spyOn(lapDeriv, "buildSegmentsFromLaps").mockReturnValue(intervals(3));
+    detSpy = spyOn(deterministic, "buildSegmentsDeterministic").mockReturnValue({
+      segments: intervals(5),
+      confidence: 1,
+      mode: "laps",
+    } as never);
+
+    const out = await produceSegments({ ...base, laps: [{}, {}] as never, declaredReps: 5 });
+
+    expect(lapSpyBuild).toHaveBeenCalledTimes(1);
+    expect(workCount(out)).toBe(5); // deterministic result, not the lap's 3
+  });
+
+  it("returns the deterministic rung when declaredReps is undefined (unchanged behavior)", async () => {
+    detSpy = spyOn(deterministic, "buildSegmentsDeterministic").mockReturnValue({
+      segments: intervals(3),
+      confidence: 1,
+      mode: "laps",
+    } as never);
+    llmSpy = spyOn(fullAnalysis, "invokeCompleteActivityAnalysisAgent");
+
+    const out = await produceSegments({ ...base, laps: [] });
+
+    expect(workCount(out)).toBe(3);
+    expect(llmSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("falls through the deterministic rung to the LLM when it contradicts declaredReps", async () => {
+    detSpy = spyOn(deterministic, "buildSegmentsDeterministic").mockReturnValue({
+      segments: intervals(3),
+      confidence: 1,
+      mode: "laps",
+    } as never);
+    llmSpy = spyOn(fullAnalysis, "invokeCompleteActivityAnalysisAgent").mockResolvedValue({
+      segments: [],
+    } as never);
+
+    await produceSegments({ ...base, laps: [], declaredReps: 5 });
+
+    expect(llmSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -102,7 +102,6 @@ mock.module("../src/services/analysis_service.ts", () => {
     ResumeValidationError,
     startAnalysis: async () => {},
     resumeAnalysis: async () => {},
-    startAnalysisByStravaId: async () => {},
     triggerAnalysisByStravaId: async () => {},
   };
 });

--- a/tests/text_intent_service.test.ts
+++ b/tests/text_intent_service.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, type Mock, spyOn } from "bun:test";
+import * as parseAgent from "../src/agent/parse_intervals_agent";
+import { extractDeclaredStructure, looksStructured } from "../src/services/text_intent_service";
+
+// looksStructured is the deterministic prefilter that decides whether text COULD
+// declare a workout structure — the hard bar is that every generic title costs
+// zero LLM calls while every structured declaration (incl. Norwegian) passes.
+const STRUCTURED = [
+  "10x1000m",
+  "10 x 1000m",
+  "6x6min",
+  "20x45/15",
+  "15x90/30s",
+  "4x1000 etterfulgt av 20x45/15",
+  "5 x (3,2,1 min)",
+  "2 x 3,2,2 km",
+  "3,2,1 km",
+  "8x60s",
+  "4x2000m",
+  "did 8 of 10",
+  "8 av 10",
+  "10x400m + 4x200m",
+  "12x200m",
+  "3km followed by 2km",
+];
+
+const GENERIC: (string | null | undefined)[] = [
+  "Morning Run",
+  "Lunch Run",
+  "Run",
+  "Easy run",
+  "Løpetur",
+  "Rolig langtur",
+  "Afternoon Run 🌞",
+  "Intervals",
+  "Marathon training week 12",
+  "",
+  "   ",
+  null,
+  undefined,
+];
+
+describe("looksStructured", () => {
+  for (const text of STRUCTURED) {
+    it(`returns true for structured "${text}"`, () => {
+      expect(looksStructured(text)).toBe(true);
+    });
+  }
+  for (const text of GENERIC) {
+    it(`returns false for generic ${JSON.stringify(text)}`, () => {
+      expect(looksStructured(text)).toBe(false);
+    });
+  }
+});
+
+describe("extractDeclaredStructure", () => {
+  let spy: Mock<typeof parseAgent.invokeParseIntervalsAgent> | undefined;
+  afterEach(() => {
+    spy?.mockRestore();
+    spy = undefined;
+  });
+
+  it("makes zero agent calls when no text looks structured", async () => {
+    spy = spyOn(parseAgent, "invokeParseIntervalsAgent");
+    const out = await extractDeclaredStructure(["Morning Run", "Run", null], null);
+    expect(out).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it("returns null when the parse agent yields empty sets", async () => {
+    spy = spyOn(parseAgent, "invokeParseIntervalsAgent").mockResolvedValue({ sets: [] });
+    const out = await extractDeclaredStructure(["10x1000m"], "LONG_INTERVALS");
+    expect(out).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the parsed sets through when non-empty", async () => {
+    const sets = [{ set_reps: 1, steps: [{ reps: 10, work_type: "DISTANCE" as const, work_value: 1000 }] }];
+    spy = spyOn(parseAgent, "invokeParseIntervalsAgent").mockResolvedValue({ sets });
+    const out = await extractDeclaredStructure(["Morning Run", "10x1000m"], null);
+    expect(out).toEqual(sets);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null (never throws) when the parse agent errors", async () => {
+    spy = spyOn(parseAgent, "invokeParseIntervalsAgent").mockRejectedValue(new Error("boom"));
+    const out = await extractDeclaredStructure(["10x1000m"], null);
+    expect(out).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

When the activity title, description, or resume-time notes explicitly declare a workout structure ("10x1000m", "4x1000 etterfulgt av 20x45/15"), the final segment structure now **deterministically matches it**; generic text ("Morning Run") provably costs zero extra LLM calls and influences nothing. Previously this was prompt-level guidance only.

Authority ladder: **resume notes → title/description → intervals.icu/laps/streams (boundaries only) → LLM.**

### Core (`src/services/text_intent_service.ts` + wiring)
- `looksStructured` — deterministic regex prefilter (incl. Norwegian notation) gating the LLM parse
- `extractDeclaredStructure` — prefilter → `invokeParseIntervalsAgent`; never throws into the pipeline
- `reconcileStructureTowardDeclared` — declared text wins on shape (rep counts, work sizes, type via the hard SHORT/LONG gate incl. the misclassify-EASY mode); model recovery kept where text is silent
- `applyPartialCompletion` — deterministic "N av/of M" notes handling ("klarte bare 8 av 10" → truncate to 8), zero LLM cost
- `structureSource: "model" | "text" | "notes"` provenance in graph state + `draftAnalysisResult`
- `produceSegments` rejects lap/deterministic rungs whose work count contradicts a text-declared rep count
- `runCompleteAnalysis` re-derives boundaries when the proposal shape disagrees with the (possibly notes-reconciled) user sets; explicit boundary edits always win

### Fixes along the way
- Shared structure-extraction prompt rules (`structure_prompt_rules.ts`) — ends D3 drift between the classifier and parse agent
- Parse agent now self-guards against the N→N² rep blowup (D4)
- Resume trainingType precedence: fresh draft beats the stale column on force re-analysis (live-found bug)
- Deleted dead `startAnalysisByStravaId`, dead icu `typeHint` branch; CLAUDE.md corrected (D6, D7)

## Test plan
- 590 pass / 0 fail (`bun run check`): unit corpus for the prefilter, reconciliation semantics, rung fall-through, N-of-M truncation
- `tests/pipeline_text_authority.test.ts` drives the real compiled LangGraph (real Postgres checkpointer) through the flagship failure mode end-to-end
- Live verification: six real activities re-analyzed through a local backend with real Strava streams + real gpt-4o-mini — text gate fired exactly where expected (e.g. classifier live-miscounted 12 reps on "10 x 1000m"; corrected to 10; compound workout now keeps both blocks: 24 work segments vs 4 before)
- Post-deploy: watch `structureSource` + correction logs in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)