### PR TITLE
fix(security): remove wildcard CORS middleware

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -28,8 +28,9 @@ const isReviewAccount = (email: string) =>
  * authorization-proxy endpoint and redirect hooks we don't use.
  *
  * Not a CSRF hole: a browser cannot send `expo-origin` cross-site — it's a
- * non-simple header, so it triggers a CORS preflight, and our CORS
- * `allowHeaders` (src/index.ts) does not list it.
+ * non-simple header, so it triggers a CORS preflight, and the server serves no
+ * Access-Control-* headers at all (no CORS middleware — see src/index.ts), so
+ * the preflight always fails.
  */
 const expoOriginBridge = {
   id: "expo-origin-bridge",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import { structuredLogger } from "@hono/structured-logger";
 import { swaggerUI } from "@hono/swagger-ui";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { Hono } from "hono";
-import { cors } from "hono/cors";
 import { requestId } from "hono/request-id";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { openAPIRouteHandler } from "hono-openapi";
@@ -119,16 +118,11 @@ app.use(
   }),
 );
 app.use("/api/*", httpInstrumentationMiddleware({ captureRequestHeaders: ["user-agent"] }));
-app.use(
-  "*",
-  cors({
-    origin: "*",
-    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization", "x-client-key"],
-    exposeHeaders: ["Content-Length", "X-Request-Id"],
-    maxAge: 3600,
-  }),
-);
+// No CORS middleware on purpose: every client is non-browser (Flutter app, MCP
+// servers, webhooks, store crawlers), and serving no Access-Control-* headers
+// means browsers block all cross-origin JS access — including any custom header
+// (Authorization, x-client-key, expo-origin) via failed preflight. If a browser
+// frontend ever appears, add hono/cors scoped to its origin only.
 app.use("/api/*", async (c, next) => {
   c.env.db = db;
   await next();


### PR DESCRIPTION
No client of this API is a browser (Flutter app, MCP servers, webhooks, store crawlers), so serving Access-Control-* headers only widened the surface: origin "*" let any website's JS read API responses it could elicit. With no CORS headers, browsers block all cross-origin JS access and every custom-header request fails preflight — which also simplifies the expoOriginBridge CSRF argument in src/auth.ts.