### PR TITLE
fix(auth): generous rate-limit customRules so OTP retries can't lock users out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,11 +132,12 @@ The SDK only starts when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so local dev is s
 
 Layered deterrence against non-app clients using the backend as a free API. MCP (`/mcp`, OAuth tokens, outside `/api/*`) is the sanctioned external door and is exempt from all of this.
 
-**Tier 1a — Better Auth's built-in IP rate limiter.** We rely on the defaults (no `rateLimit` block in `src/auth.ts`). Verified against `better-auth@1.6.23` (`dist/context/create-context.mjs`, `dist/api/rate-limiter/index.mjs`):
+**Tier 1a — Better Auth's built-in IP rate limiter.** Defaults plus generous `rateLimit.customRules` overrides in `src/auth.ts` — the built-in auth-path rules (3/10s) locked a real user out mid-flow (observed 2026-07-10: a retried OTP + resend spiralled into ~25 429s and no successful sign-in). The limiter is an anti-spam backstop only; OTP brute-force protection is the plugin's `allowedAttempts: 5`. Verified against `better-auth@1.6.23` (`dist/context/create-context.mjs`, `dist/api/rate-limiter/index.mjs`; `customRules` match the normalized path relative to `/api/auth` and take precedence over the built-in special rules):
 - **Enabled in production only** (`enabled ?? isProduction`) — silent in dev/`test`. In-memory `memory` store (fine on single-instance Railway; if it ever goes multi-instance, set `rateLimit.storage: "database"`).
-- Global default **100 requests / 10 s per IP** (window `10`, max `100`).
-- Special rule for `/sign-in*`, `/sign-up*`, `/change-password*`, `/change-email*`: **3 / 10 s**.
-- emailOTP `/email-otp/send-verification-otp` (and other OTP send/reset paths): **3 / 60 s**. The app's resend cooldown is 20 s, so a real user never trips it.
+- Global default **100 requests / 10 s per IP** (window `10`, max `100`) — untouched.
+- `/sign-in/email-otp` and `/sign-up/email-otp`: **30 / 60 s** (override; built-in `/sign-in*` `/sign-up*` rule is 3/10s).
+- `/email-otp/send-verification-otp`: **10 / 60 s** (override; built-in is 3/60s) — still caps mail-bombing while never touching the app's 20 s resend cooldown.
+- Remaining built-in special rules (`/change-password*`, `/change-email*`, password-reset sends) keep their tight defaults — those flows are unused.
 
 **Tier 1b — per-user daily quotas on LLM-backed endpoints** (`src/middlewares/quota_middleware.ts`, always on, in-memory per UTC day). Generous by design — a real user never hits them; the analysis cap is a circuit breaker against scripted model spend:
 - `POST /api/v1/agents/suggest-session` — 100/user/day (429 over cap)

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -163,6 +163,20 @@ export const auth = betterAuth({
   // `intervalinsights://` is the native app scheme, trusted so the expo-origin
   // bridge above satisfies the CSRF check for cookie-bearing app requests.
   trustedOrigins: [new URL(config.APP_BASE_URL).origin, "intervalinsights://"],
+  // Override Better Auth's built-in per-IP rules (sign-in/sign-up 3/10s, OTP
+  // send 3/60s) — tight enough that a real user retrying a mistyped code plus
+  // a resend gets locked out mid-flow (observed in prod 2026-07-10). These are
+  // anti-spam backstops only: generous enough that no legitimate user ever
+  // trips them. Brute-force protection on the code itself is `allowedAttempts`
+  // below, not the limiter. Global default (100/10s) and prod-only enablement
+  // stay untouched.
+  rateLimit: {
+    customRules: {
+      "/sign-in/email-otp": { window: 60, max: 30 },
+      "/sign-up/email-otp": { window: 60, max: 30 },
+      "/email-otp/send-verification-otp": { window: 60, max: 10 },
+    },
+  },
   databaseHooks: {
     user: {
       create: {


### PR DESCRIPTION
## Why

Prod Grafana logs (2026-07-10, 13:10–13:17 UTC) show a real user stuck in the email-OTP flow: ~25 `429`s in 7 minutes and zero successful sign-ins. Better Auth's built-in per-IP rules are tuned for password flows — `/sign-in*` & `/sign-up*` at **3 req / 10 s**, OTP send at **3 / 60 s** — so one mistyped code plus a resend exhausts the budget, and the 429s then block the verify call itself: a lockout spiral.

## What

Generous `rateLimit.customRules` overrides in `src/auth.ts` (verified against `better-auth@1.6.23`: customRules take precedence over the built-in special rules):

| Path | Built-in | Now |
|---|---|---|
| `/sign-in/email-otp` | 3 / 10 s | 30 / 60 s |
| `/sign-up/email-otp` | 3 / 10 s | 30 / 60 s |
| `/email-otp/send-verification-otp` | 3 / 60 s | 10 / 60 s |

The limiter stays an anti-spam backstop only — no legitimate user can trip these, while scripted hammering is still cut off. OTP brute-force protection is unchanged and lives in the plugin's `allowedAttempts: 5` (code destroyed after 5 wrong tries). Global default (100/10 s) and prod-only enablement untouched. OTP send stays tighter than the sign-in paths since each send costs a Resend email; 10/min never touches the app's 20 s resend cooldown.

CLAUDE.md's Tier 1a section updated to match.

## Verification

- `tsc --noEmit` (src/) and `biome check src` pass.
- No test exercises the limiter — it is production-only (`enabled ?? isProduction`), so the suite can't observe it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)