### PR TITLE
feat(admin): add Strava and intervals.icu connection counts to /admin…

### DIFF
--- a/src/repositories/user_repository.ts
+++ b/src/repositories/user_repository.ts
@@ -1,6 +1,7 @@
-import { and, count, desc, eq, gte, ilike, or, type SQL, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, ilike, isNotNull, ne, or, type SQL, sql } from "drizzle-orm";
 import { type InsertUser, type SelectUser, users } from "../schema";
 import type { UserRole } from "../schema/enums";
+import { REVIEW_STRAVA_ID } from "../services/review_account";
 import type { IGlobalBindings } from "../types/IRouters";
 
 type Db = IGlobalBindings["db"];
@@ -17,6 +18,8 @@ export interface UserStats {
   newToday: number;
   newThisWeek: number;
   bannedCount: number;
+  stravaConnected: number;
+  intervalsConnected: number;
   roleBreakdown: { guest: number; premium: number; admin: number };
 }
 
@@ -37,6 +40,10 @@ export async function getUserStats(db: Db): Promise<UserStats> {
       newToday: countWhere(gte(users.createdAt, dayAgo)),
       newThisWeek: countWhere(gte(users.createdAt, weekAgo)),
       bannedCount: countWhere(eq(users.banned, true)),
+      // `<> '0'` also drops NULLs (SQL three-valued logic), so this counts real
+      // Strava links only — excluding the store-review demo account's "0" sentinel.
+      stravaConnected: countWhere(ne(users.stravaId, REVIEW_STRAVA_ID)),
+      intervalsConnected: countWhere(isNotNull(users.intervalsAthleteId)),
       guest: countWhere(eq(users.role, "guest")),
       premium: countWhere(eq(users.role, "premium")),
       admin: countWhere(eq(users.role, "admin")),
@@ -51,6 +58,8 @@ export async function getUserStats(db: Db): Promise<UserStats> {
     newToday: row?.newToday ?? 0,
     newThisWeek: row?.newThisWeek ?? 0,
     bannedCount: row?.bannedCount ?? 0,
+    stravaConnected: row?.stravaConnected ?? 0,
+    intervalsConnected: row?.intervalsConnected ?? 0,
     roleBreakdown: {
       guest: row?.guest ?? 0,
       premium: row?.premium ?? 0,

--- a/src/schemas/admin_schemas.ts
+++ b/src/schemas/admin_schemas.ts
@@ -11,6 +11,8 @@ export const AdminStatsSchema = z
     newToday: z.number(),
     newThisWeek: z.number(),
     bannedCount: z.number(),
+    stravaConnected: z.number(),
+    intervalsConnected: z.number(),
     roleBreakdown: z.object({
       guest: z.number(),
       premium: z.number(),

--- a/src/services/review_account.ts
+++ b/src/services/review_account.ts
@@ -1,5 +1,9 @@
 import { config } from "../config";
 
+// Placeholder `users.strava_id` for the store-review demo account — it satisfies
+// the app's "is Strava linked" checks without a real Strava athlete behind it.
+export const REVIEW_STRAVA_ID = "0";
+
 export function isReviewAccountEmail(email: string): boolean {
   return (
     config.REVIEW_ACCOUNT_EMAIL !== undefined && email.toLowerCase() === config.REVIEW_ACCOUNT_EMAIL

--- a/src/services/review_demo/seed.ts
+++ b/src/services/review_demo/seed.ts
@@ -18,7 +18,7 @@ import {
   intervalStructures,
   users,
 } from "../../schema";
-import { setReviewUserId } from "../review_account";
+import { REVIEW_STRAVA_ID, setReviewUserId } from "../review_account";
 import { buildDemoCorpus } from "./corpus";
 
 // Cheap, safe on every boot: resolve the review user, promote it (provider
@@ -36,7 +36,12 @@ export async function prepareReviewAccount(): Promise<string | null> {
 
   await db
     .update(users)
-    .set({ stravaId: "0", role: "premium", maxHeartRate: 190, processHeartRate: true })
+    .set({
+      stravaId: REVIEW_STRAVA_ID,
+      role: "premium",
+      maxHeartRate: 190,
+      processHeartRate: true,
+    })
     .where(eq(users.id, user.id));
   setReviewUserId(user.id);
   return user.id;

--- a/tests/admin_stats.test.ts
+++ b/tests/admin_stats.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { eq } from "drizzle-orm";
+import { getUserStats } from "../src/repositories/user_repository";
+import { users } from "../src/schema";
+import { REVIEW_STRAVA_ID } from "../src/services/review_account";
+import { closePool, createTestUser, deleteTestUser, getDb } from "./helpers/db";
+
+// getUserStats counts every row in the shared test DB, so assert on deltas
+// against a baseline rather than absolute totals.
+const db = getDb();
+
+let stravaUser: { id: string };
+let intervalsUser: { id: string };
+let reviewUser: { id: string };
+let unconnectedUser: { id: string };
+let baseline: Awaited<ReturnType<typeof getUserStats>>;
+let after: Awaited<ReturnType<typeof getUserStats>>;
+
+beforeAll(async () => {
+  baseline = await getUserStats(db);
+
+  stravaUser = await createTestUser({ strava: false, intervals: false });
+  intervalsUser = await createTestUser({ strava: false, intervals: false });
+  reviewUser = await createTestUser({ strava: false, intervals: false });
+  unconnectedUser = await createTestUser({ strava: false, intervals: false });
+
+  await db
+    .update(users)
+    .set({ stravaId: `test_strava_${stravaUser.id}` })
+    .where(eq(users.id, stravaUser.id));
+  await db
+    .update(users)
+    .set({ intervalsAthleteId: `test_intervals_${intervalsUser.id}` })
+    .where(eq(users.id, intervalsUser.id));
+  await db
+    .update(users)
+    .set({ stravaId: REVIEW_STRAVA_ID })
+    .where(eq(users.id, reviewUser.id));
+
+  after = await getUserStats(db);
+});
+
+afterAll(async () => {
+  await deleteTestUser(stravaUser.id);
+  await deleteTestUser(intervalsUser.id);
+  await deleteTestUser(reviewUser.id);
+  await deleteTestUser(unconnectedUser.id);
+  await closePool();
+});
+
+describe("getUserStats connection counts", () => {
+  it("counts a user with a real strava_id", () => {
+    expect(after.stravaConnected - baseline.stravaConnected).toBe(1);
+  });
+
+  it("counts a user with an intervals_athlete_id", () => {
+    expect(after.intervalsConnected - baseline.intervalsConnected).toBe(1);
+  });
+
+  it("excludes the review demo account's strava_id sentinel", () => {
+    // Four users added, two of them carry a non-null strava_id — only the
+    // non-sentinel one is a real connection.
+    expect(after.totalUsers - baseline.totalUsers).toBe(4);
+    expect(after.stravaConnected - baseline.stravaConnected).toBe(1);
+  });
+});


### PR DESCRIPTION
…/stats

Counts real provider links only — the review demo account's strava_id sentinel is excluded via a new REVIEW_STRAVA_ID constant.