### PR TITLE
fix(webhooks): zero-distance cross-source dedup, orphan Strava update…

### DIFF
--- a/src/agent/graph_state.ts
+++ b/src/agent/graph_state.ts
@@ -34,7 +34,12 @@ export const AnalysisStateAnnotation = Annotation.Root({
   isIndoor: Annotation<boolean>({ reducer: overwrite, default: () => false }),
   activityTitle: Annotation<string>({ reducer: overwrite, default: () => "" }),
   activityDescription: Annotation<string>({ reducer: overwrite, default: () => "" }),
-  activityStartDateLocal: Annotation<Date | null>({ reducer: overwrite, default: () => null }),
+  // `string` is not a lie: every node after the interrupt reads this back off the
+  // LangGraph checkpointer, which round-trips state through JSON.
+  activityStartDateLocal: Annotation<Date | string | null>({
+    reducer: overwrite,
+    default: () => null,
+  }),
   activityType: Annotation<string>({ reducer: overwrite, default: () => "" }),
   totalElevationGain: Annotation<number>({ reducer: overwrite, default: () => 0 }),
   streams: Annotation<StreamSet | null>({ reducer: overwrite, default: () => null }),

--- a/src/services/activity_match.ts
+++ b/src/services/activity_match.ts
@@ -1,17 +1,13 @@
 export const TIME_TOLERANCE_MS = 5 * 60 * 1000;
 export const DISTANCE_TOLERANCE_RATIO = 0.03;
+export const DURATION_TOLERANCE_RATIO = 0.02;
+export const MIN_DURATION_TOLERANCE_SECONDS = 60;
 
-export function withinMatchTolerance(
-  refStartMs: number,
-  refDistance: number | null | undefined,
-  candidateStartMs: number,
-  candidateDistance: number | null | undefined,
-): boolean {
-  if (Number.isNaN(refStartMs) || Number.isNaN(candidateStartMs)) return false;
-  if (refDistance == null || candidateDistance == null) return false;
-  if (Math.abs(refStartMs - candidateStartMs) > TIME_TOLERANCE_MS) return false;
-  const { min, max } = distanceBand(refDistance);
-  return candidateDistance >= min && candidateDistance <= max;
+export interface MatchSubject {
+  startMs: number;
+  distance: number | null | undefined;
+  movingTime?: number | null;
+  sportType?: string | null;
 }
 
 export function distanceBand(distance: number): { min: number; max: number } {
@@ -19,4 +15,42 @@ export function distanceBand(distance: number): { min: number; max: number } {
     min: distance * (1 - DISTANCE_TOLERANCE_RATIO),
     max: distance * (1 + DISTANCE_TOLERANCE_RATIO),
   };
+}
+
+export function durationBand(seconds: number): { min: number; max: number } {
+  const tolerance = Math.max(MIN_DURATION_TOLERANCE_SECONDS, seconds * DURATION_TOLERANCE_RATIO);
+  return { min: seconds - tolerance, max: seconds + tolerance };
+}
+
+/**
+ * Distance band when both sides actually measure distance, duration band when
+ * neither does. Zero-distance sports (Elliptical, WeightTraining, Yoga, pool
+ * Swim) store `distance: 0` from every provider, so a distance-only comparison
+ * can never match them across sources.
+ */
+export function withinMatchTolerance(ref: MatchSubject, candidate: MatchSubject): boolean {
+  if (Number.isNaN(ref.startMs) || Number.isNaN(candidate.startMs)) return false;
+  if (Math.abs(ref.startMs - candidate.startMs) > TIME_TOLERANCE_MS) return false;
+
+  const refDistance = ref.distance;
+  const candidateDistance = candidate.distance;
+  if (refDistance == null || candidateDistance == null) return false;
+
+  if (refDistance > 0 || candidateDistance > 0) {
+    if (refDistance <= 0 || candidateDistance <= 0) return false;
+    const { min, max } = distanceBand(refDistance);
+    return candidateDistance >= min && candidateDistance <= max;
+  }
+
+  // Start time alone is weak evidence — zero-distance sports cluster (gym then
+  // yoga), so the fallback also demands the same sport and a similar duration.
+  if (!sameSport(ref.sportType, candidate.sportType)) return false;
+  if (ref.movingTime == null || candidate.movingTime == null) return false;
+  const { min, max } = durationBand(ref.movingTime);
+  return candidate.movingTime >= min && candidate.movingTime <= max;
+}
+
+function sameSport(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (!a || !b) return false;
+  return a.toLowerCase() === b.toLowerCase();
 }

--- a/src/services/event_detection_service.ts
+++ b/src/services/event_detection_service.ts
@@ -48,7 +48,7 @@ export type EventDetectionInput = {
   title: string;
   description: string;
   notes: string;
-  activityStartDateLocal: Date | null;
+  activityStartDateLocal: Date | string | null;
 };
 
 export async function detectAndPersistEvents(

--- a/src/services/intervals_link_service.ts
+++ b/src/services/intervals_link_service.ts
@@ -7,7 +7,7 @@ import { activities, type InsertActivity, users } from "../schema";
 import type { IGlobalBindings } from "../types/IRouters";
 import type { IIntervalsActivity } from "../types/intervals/IIntervalsActivity";
 import { computeAndStoreActivityLoad } from "./activity_load_service";
-import { distanceBand, TIME_TOLERANCE_MS, withinMatchTolerance } from "./activity_match";
+import { type MatchSubject, TIME_TOLERANCE_MS, withinMatchTolerance } from "./activity_match";
 import { userHasHeartRateConsent } from "./heart_rate_consent_service";
 import { classifyUserActivity } from "./ingest_gating";
 import { intervalsApiService } from "./intervals_api_service";
@@ -80,21 +80,34 @@ export interface LinkResult {
   intervalsActivityId: string;
 }
 
+function intervalsMatchSubject(intervalsActivity: IIntervalsActivity): MatchSubject {
+  return {
+    startMs: parseIntervalsLocalStartMs(intervalsActivity.start_date_local),
+    distance: intervalsActivity.distance ?? 0,
+    movingTime: intervalsActivity.moving_time ?? null,
+    sportType: intervalsActivity.type ?? null,
+  };
+}
+
 async function findLocalByFuzzyMatch(
   db: Executor,
   userId: string,
   intervalsActivity: IIntervalsActivity,
 ): Promise<{ id: number } | null> {
-  const startMs = parseIntervalsLocalStartMs(intervalsActivity.start_date_local);
-  if (Number.isNaN(startMs)) return null;
-  if (intervalsActivity.distance == null) return null;
+  const ref = intervalsMatchSubject(intervalsActivity);
+  if (Number.isNaN(ref.startMs)) return null;
 
-  const minTime = new Date(startMs - TIME_TOLERANCE_MS);
-  const maxTime = new Date(startMs + TIME_TOLERANCE_MS);
-  const { min: minDistance, max: maxDistance } = distanceBand(intervalsActivity.distance);
+  const minTime = new Date(ref.startMs - TIME_TOLERANCE_MS);
+  const maxTime = new Date(ref.startMs + TIME_TOLERANCE_MS);
 
   const candidates = await db
-    .select({ id: activities.id })
+    .select({
+      id: activities.id,
+      startDateLocal: activities.startDateLocal,
+      distance: activities.distance,
+      movingTime: activities.movingTime,
+      sportType: activities.sportType,
+    })
     .from(activities)
     .where(
       and(
@@ -102,13 +115,20 @@ async function findLocalByFuzzyMatch(
         isNull(activities.intervalsIcuId),
         gte(activities.startDateLocal, minTime),
         lte(activities.startDateLocal, maxTime),
-        gte(activities.distance, minDistance),
-        lte(activities.distance, maxDistance),
       ),
     );
 
-  if (candidates.length !== 1) return null;
-  return candidates[0];
+  const matches = candidates.filter((c) =>
+    withinMatchTolerance(ref, {
+      startMs: c.startDateLocal.getTime(),
+      distance: c.distance,
+      movingTime: c.movingTime,
+      sportType: c.sportType,
+    }),
+  );
+
+  if (matches.length !== 1) return null;
+  return { id: matches[0].id };
 }
 
 async function commitLink(
@@ -336,6 +356,8 @@ export async function linkFromLocalActivity(
       id: true,
       startDateLocal: true,
       distance: true,
+      movingTime: true,
+      sportType: true,
       intervalsIcuId: true,
       stravaActivityId: true,
     },
@@ -379,16 +401,15 @@ export async function linkFromLocalActivity(
     }
   }
 
-  const fuzzy = candidates.filter((candidate) => {
-    const candidateStart = parseIntervalsLocalStartMs(candidate.start_date_local);
-    if (Number.isNaN(candidateStart)) return false;
-    return withinMatchTolerance(
-      candidateStart,
-      candidate.distance,
-      localStartMs,
-      activity.distance,
-    );
-  });
+  const local: MatchSubject = {
+    startMs: localStartMs,
+    distance: activity.distance,
+    movingTime: activity.movingTime,
+    sportType: activity.sportType,
+  };
+  const fuzzy = candidates.filter((candidate) =>
+    withinMatchTolerance(intervalsMatchSubject(candidate), local),
+  );
   if (fuzzy.length !== 1) return null;
 
   let full: IIntervalsActivity;
@@ -480,10 +501,8 @@ export interface MasterSyncResult extends SyncIntervalsResult {
   processed: number;
 }
 
-type FuzzyLocal = {
+type FuzzyLocal = MatchSubject & {
   id: number;
-  startMs: number;
-  distance: number;
   stravaActivityId: number | null;
 };
 
@@ -496,12 +515,12 @@ function findUniqueInMemoryMatch(
     if (exact.length === 1) return exact[0];
   }
 
-  const startMs = parseIntervalsLocalStartMs(intervalsActivity.start_date_local);
-  if (Number.isNaN(startMs)) return null;
+  const ref = intervalsMatchSubject(intervalsActivity);
+  if (Number.isNaN(ref.startMs)) return null;
 
   let found: FuzzyLocal | null = null;
   for (const local of locals) {
-    if (withinMatchTolerance(startMs, intervalsActivity.distance, local.startMs, local.distance)) {
+    if (withinMatchTolerance(ref, local)) {
       if (found) return null;
       found = local;
     }
@@ -558,6 +577,8 @@ export async function syncAllFromIntervals(
         id: activities.id,
         startDateLocal: activities.startDateLocal,
         distance: activities.distance,
+        movingTime: activities.movingTime,
+        sportType: activities.sportType,
         intervalsIcuId: activities.intervalsIcuId,
         stravaActivityId: activities.stravaActivityId,
       })
@@ -574,6 +595,8 @@ export async function syncAllFromIntervals(
           id: row.id,
           startMs: row.startDateLocal.getTime(),
           distance: row.distance,
+          movingTime: row.movingTime,
+          sportType: row.sportType,
           stravaActivityId: row.stravaActivityId,
         });
       }

--- a/src/services/process_strava_event.ts
+++ b/src/services/process_strava_event.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, isNotNull, isNull, lte } from "drizzle-orm";
+import { and, eq, gte, isNotNull, isNull, lte, sql } from "drizzle-orm";
 import { logger } from "../logger";
 import { getStravaAccessTokens } from "../middlewares/strava_middleware";
 import * as gearRepo from "../repositories/gear_repository";
@@ -7,7 +7,7 @@ import { activities, gears, type InsertActivity, users } from "../schema";
 import type { IGlobalBindings } from "../types/IRouters";
 import type { IStravaWebhookEvent } from "../types/strava/IWebHookEvent";
 import { computeAndStoreActivityLoad } from "./activity_load_service";
-import { distanceBand, TIME_TOLERANCE_MS } from "./activity_match";
+import { TIME_TOLERANCE_MS, withinMatchTolerance } from "./activity_match";
 import { triggerAnalysisByStravaId } from "./analysis_service";
 import { linkActivityGearOnIngest, relinkActivityGearFromStrava } from "./gear_strava_service";
 import { userHasHeartRateConsent } from "./heart_rate_consent_service";
@@ -18,20 +18,28 @@ import { stravaApiService } from "./strava_api_service";
 import { getDbInsertActivity } from "./strava_mappers";
 import { shouldAnalyze } from "./utils";
 
+type Db = IGlobalBindings["db"];
+type Executor = Db | Parameters<Parameters<Db["transaction"]>[0]>[0];
+
 async function findFuzzyIntervalsTwin(
-  context: IGlobalBindings,
+  db: Executor,
   userId: string,
   activity: InsertActivity,
 ): Promise<{ id: number } | null> {
-  if (activity.startDateLocal == null || !activity.distance || activity.distance <= 0) return null;
+  if (activity.startDateLocal == null) return null;
 
   const startMs = activity.startDateLocal.getTime();
   const minTime = new Date(startMs - TIME_TOLERANCE_MS);
   const maxTime = new Date(startMs + TIME_TOLERANCE_MS);
-  const { min, max } = distanceBand(activity.distance);
 
-  const candidates = await context.db
-    .select({ id: activities.id })
+  const candidates = await db
+    .select({
+      id: activities.id,
+      startDateLocal: activities.startDateLocal,
+      distance: activities.distance,
+      movingTime: activities.movingTime,
+      sportType: activities.sportType,
+    })
     .from(activities)
     .where(
       and(
@@ -40,13 +48,115 @@ async function findFuzzyIntervalsTwin(
         isNotNull(activities.intervalsIcuId),
         gte(activities.startDateLocal, minTime),
         lte(activities.startDateLocal, maxTime),
-        gte(activities.distance, min),
-        lte(activities.distance, max),
       ),
     );
 
-  if (candidates.length !== 1) return null;
-  return candidates[0];
+  const matches = candidates.filter((c) =>
+    withinMatchTolerance(
+      {
+        startMs,
+        distance: activity.distance,
+        movingTime: activity.movingTime,
+        sportType: activity.sportType,
+      },
+      {
+        startMs: c.startDateLocal.getTime(),
+        distance: c.distance,
+        movingTime: c.movingTime,
+        sportType: c.sportType,
+      },
+    ),
+  );
+
+  if (matches.length !== 1) return null;
+  return { id: matches[0].id };
+}
+
+type ExistingRow = {
+  id: number;
+  distance: number;
+  gearId: string | null;
+  analysisStatus: (typeof activities.$inferSelect)["analysisStatus"];
+};
+
+function selectByStravaId(
+  db: Executor,
+  userId: string,
+  stravaActivityId: number,
+): Promise<ExistingRow[]> {
+  return db
+    .select({
+      id: activities.id,
+      distance: activities.distance,
+      gearId: activities.gearId,
+      analysisStatus: activities.analysisStatus,
+    })
+    .from(activities)
+    .where(and(eq(activities.stravaActivityId, stravaActivityId), eq(activities.userId, userId)));
+}
+
+type Resolution =
+  | { kind: "duplicate"; id: number }
+  | { kind: "updated"; id: number; previous: ExistingRow }
+  | { kind: "merged"; id: number; via: "exact" | "fuzzy" }
+  | { kind: "created"; id: number }
+  | { kind: "dropped" };
+
+/**
+ * One dedup implementation for both `create` and `update`. Serialized per user
+ * with an advisory lock because Strava dispatches the two events for the same
+ * activity seconds apart and both handlers run fire-and-forget — without it
+ * they race into two inserts.
+ */
+async function resolveActivityRow(
+  db: Db,
+  userId: string,
+  stravaActivityId: number,
+  aspect: "create" | "update",
+  activity: InsertActivity,
+  payload: InsertActivity,
+): Promise<Resolution> {
+  return db.transaction(async (tx): Promise<Resolution> => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${userId}))`);
+
+    const applyUpdate = async (row: ExistingRow): Promise<Resolution> => {
+      if (aspect === "create") return { kind: "duplicate", id: row.id };
+      await tx.update(activities).set(activity).where(eq(activities.id, row.id));
+      return { kind: "updated", id: row.id, previous: row };
+    };
+
+    const [existing] = await selectByStravaId(tx, userId, stravaActivityId);
+    if (existing) return applyUpdate(existing);
+
+    const exactTwin = await tx.query.activities.findFirst({
+      where: (a, { and, eq, isNull }) =>
+        and(
+          eq(a.userId, userId),
+          eq(a.intervalsStravaId, stravaActivityId),
+          isNull(a.stravaActivityId),
+        ),
+      columns: { id: true },
+    });
+    const twin = exactTwin ?? (await findFuzzyIntervalsTwin(tx, userId, activity));
+    if (twin) {
+      await tx
+        .update(activities)
+        .set({ ...payload, analysisStatus: payload.analysisStatus ?? "pending" })
+        .where(eq(activities.id, twin.id));
+      return { kind: "merged", id: twin.id, via: exactTwin ? "exact" : "fuzzy" };
+    }
+
+    const [inserted] = await tx
+      .insert(activities)
+      .values(payload)
+      .onConflictDoNothing()
+      .returning({ id: activities.id });
+    if (inserted) return { kind: "created", id: inserted.id };
+
+    const [raced] = await selectByStravaId(tx, userId, stravaActivityId);
+    if (!raced) return { kind: "dropped" };
+    return applyUpdate(raced);
+  });
 }
 
 /**
@@ -74,6 +184,16 @@ async function maybeStartImmediateAnalysis(
 
 export async function processStravaWebhook(body: IStravaWebhookEvent, context: IGlobalBindings) {
   if (body.object_type === "athlete" && body.aspect_type === "update") {
+    // Strava documents athlete-updates only for deauthorization, but the branch
+    // below wipes the account — never take it on an unrecognised payload.
+    if (body.updates?.authorized !== "false") {
+      logger.warn(
+        { athleteId: body.owner_id, updates: body.updates },
+        "Ignoring Strava athlete update — not a deauthorization",
+      );
+      return;
+    }
+
     const user = await context.db.query.users.findFirst({
       where: (u, { eq }) => eq(u.stravaId, body.owner_id.toString()),
     });
@@ -152,91 +272,55 @@ export async function processStravaWebhook(body: IStravaWebhookEvent, context: I
     );
     return;
   }
+  if (activityClass === "skip") {
+    logger.info(
+      { stravaActivityId, userId: user.id, inactiveDays: INACTIVITY_SKIP_DAYS },
+      "Storing as skipped_inactive — user inactive",
+    );
+  }
 
-  if (body.aspect_type === "create") {
-    const payload =
-      activityClass === "skip"
-        ? { ...activity, analysisStatus: "skipped_inactive" as const }
-        : activity;
-    if (activityClass === "skip") {
-      logger.info(
-        { stravaActivityId, userId: user.id, inactiveDays: INACTIVITY_SKIP_DAYS },
-        "Storing as skipped_inactive — user inactive",
-      );
-    }
+  const payload: InsertActivity =
+    activityClass === "skip"
+      ? { ...activity, analysisStatus: "skipped_inactive" as const }
+      : activity;
 
-    const exactTwin = await context.db.query.activities.findFirst({
-      where: (a, { and, eq, isNull }) =>
-        and(
-          eq(a.userId, user.id),
-          eq(a.intervalsStravaId, stravaActivityId),
-          isNull(a.stravaActivityId),
-        ),
-      columns: { id: true },
-    });
-    const twin = exactTwin ?? (await findFuzzyIntervalsTwin(context, user.id, activity));
+  const resolved = await resolveActivityRow(
+    context.db,
+    user.id,
+    stravaActivityId,
+    body.aspect_type,
+    activity,
+    payload,
+  );
 
-    if (twin) {
-      await context.db
-        .update(activities)
-        .set({ ...payload, analysisStatus: payload.analysisStatus ?? "pending" })
-        .where(eq(activities.id, twin.id));
-      if (data.gear_id && activity.startDateLocal) {
-        await linkActivityGearOnIngest(context.db, user.id, accessToken, twin.id, {
-          stravaGearId: data.gear_id,
-          sportType: data.sport_type,
-          indoor: data.trainer ?? false,
-          startDateLocal: activity.startDateLocal,
-        });
-      }
-      logger.info(
-        {
-          stravaActivityId,
-          userId: user.id,
-          mergedInto: twin.id,
-          via: exactTwin ? "exact" : "fuzzy",
-        },
-        "Strava create merged into existing intervals.icu row (dedup)",
-      );
-      if (activityClass === "active") {
-        await progressService.publish(user.id, {
-          type: "progress",
-          data: {
-            id: twin.id,
-            kind: "strava_ingest",
-            phase: "received",
-            analysisStatus: "pending",
-            title: activity.title ?? undefined,
-            startDateLocal: activity.startDateLocal?.toISOString(),
-          },
-        });
-        await maybeStartImmediateAnalysis(context, accessToken, stravaActivityId, user.id, twin.id);
-      }
-      await computeAndStoreActivityLoad(context.db, user.id, twin.id);
-      return;
-    }
+  if (resolved.kind === "dropped" || resolved.kind === "duplicate") return;
 
-    const [inserted] = await context.db
-      .insert(activities)
-      .values(payload)
-      .onConflictDoNothing()
-      .returning({ id: activities.id });
-    if (inserted && data.gear_id && activity.startDateLocal) {
-      await linkActivityGearOnIngest(context.db, user.id, accessToken, inserted.id, {
+  if (resolved.kind === "merged") {
+    logger.info(
+      { stravaActivityId, userId: user.id, mergedInto: resolved.id, via: resolved.via },
+      "Strava event merged into existing intervals.icu row (dedup)",
+    );
+  }
+
+  const activityId = resolved.id;
+
+  if (resolved.kind === "created" || resolved.kind === "merged") {
+    if (data.gear_id && activity.startDateLocal) {
+      await linkActivityGearOnIngest(context.db, user.id, accessToken, activityId, {
         stravaGearId: data.gear_id,
         sportType: data.sport_type,
         indoor: data.trainer ?? false,
         startDateLocal: activity.startDateLocal,
       });
     }
-    if (activityClass === "active" && inserted) {
+    if (activityClass === "active") {
       await progressService.publish(user.id, {
         type: "progress",
         data: {
-          id: inserted.id,
+          id: activityId,
           kind: "strava_ingest",
           phase: "received",
-          analysisStatus: "pending",
+          analysisStatus: payload.analysisStatus ?? "pending",
           title: activity.title ?? undefined,
           startDateLocal: activity.startDateLocal?.toISOString(),
         },
@@ -246,78 +330,68 @@ export async function processStravaWebhook(body: IStravaWebhookEvent, context: I
         accessToken,
         stravaActivityId,
         user.id,
-        inserted.id,
+        activityId,
       );
-    }
-    if (inserted) await computeAndStoreActivityLoad(context.db, user.id, inserted.id);
-    return;
-  }
-
-  if (body.aspect_type === "update") {
-    const [existing] = await context.db
-      .select({
-        id: activities.id,
-        distance: activities.distance,
-        gearId: activities.gearId,
-        analysisStatus: activities.analysisStatus,
-      })
-      .from(activities)
-      .where(
-        and(eq(activities.stravaActivityId, stravaActivityId), eq(activities.userId, user.id)),
-      );
-    if (!existing) return;
-    await context.db.update(activities).set(activity).where(eq(activities.id, existing.id));
-    await gearRepo.adjustForDistanceChange(
-      context.db,
-      existing.id,
-      existing.distance,
-      activity.distance,
-    );
-    const newStravaGearId = data.gear_id ?? null;
-    if (newStravaGearId !== (existing.gearId ?? null) && activity.startDateLocal) {
-      const relinked = await relinkActivityGearFromStrava(
-        context.db,
-        user.id,
-        accessToken,
-        existing.id,
-        {
-          stravaGearId: newStravaGearId,
-          sportType: data.sport_type,
-          indoor: data.trainer ?? false,
-          startDateLocal: activity.startDateLocal,
-        },
-      );
-      if (relinked) {
-        await context.db
-          .update(activities)
-          .set({ gearUpdatedFromStrava: true })
-          .where(eq(activities.id, existing.id));
-      }
-    }
-    // Surface the edit to the app whenever a user-visible field actually changed
-    // (gate on the webhook's `updates` keys, not every update event). Fires even
-    // when the analysis restart is skipped by SKIP_RESTART_STATUSES — otherwise a
-    // completed activity keeps a stale title in the app (the stale-title fix).
-    const relevantUpdate =
-      body.updates?.title != null ||
-      body.updates?.description != null ||
-      body.updates?.gear_id != null;
-    if (activityClass === "active" && relevantUpdate) {
-      await progressService.publish(user.id, {
-        type: "progress",
-        data: {
-          id: existing.id,
-          kind: "strava_ingest",
-          phase: "updated",
-          analysisStatus: existing.analysisStatus ?? undefined,
-          title: activity.title ?? undefined,
-          startDateLocal: activity.startDateLocal?.toISOString(),
-        },
-      });
-      if (body.updates?.title || body.updates?.description) {
+      // An `update` that had to create the row still carries the user's edit.
+      if (body.aspect_type === "update" && (body.updates?.title || body.updates?.description)) {
         await triggerAnalysisByStravaId(context.db, accessToken, stravaActivityId, user.id);
       }
     }
-    await computeAndStoreActivityLoad(context.db, user.id, existing.id);
+    await computeAndStoreActivityLoad(context.db, user.id, activityId);
+    return;
   }
+
+  const previous = resolved.previous;
+  await gearRepo.adjustForDistanceChange(
+    context.db,
+    activityId,
+    previous.distance,
+    activity.distance,
+  );
+  const newStravaGearId = data.gear_id ?? null;
+  if (newStravaGearId !== (previous.gearId ?? null) && activity.startDateLocal) {
+    const relinked = await relinkActivityGearFromStrava(
+      context.db,
+      user.id,
+      accessToken,
+      activityId,
+      {
+        stravaGearId: newStravaGearId,
+        sportType: data.sport_type,
+        indoor: data.trainer ?? false,
+        startDateLocal: activity.startDateLocal,
+      },
+    );
+    if (relinked) {
+      await context.db
+        .update(activities)
+        .set({ gearUpdatedFromStrava: true })
+        .where(eq(activities.id, activityId));
+    }
+  }
+  // Surface the edit to the app whenever a user-visible field actually changed
+  // (gate on the webhook's `updates` keys, not every update event). Fires even
+  // when the analysis restart is skipped by SKIP_RESTART_STATUSES — otherwise a
+  // completed activity keeps a stale title in the app (the stale-title fix).
+  const relevantUpdate =
+    body.updates?.title != null ||
+    body.updates?.description != null ||
+    body.updates?.gear_id != null;
+  if (activityClass === "active" && relevantUpdate) {
+    await progressService.publish(user.id, {
+      type: "progress",
+      data: {
+        id: activityId,
+        kind: "strava_ingest",
+        phase: "updated",
+        analysisStatus: previous.analysisStatus ?? undefined,
+        title: activity.title ?? undefined,
+        startDateLocal: activity.startDateLocal?.toISOString(),
+      },
+    });
+    if (body.updates?.title || body.updates?.description) {
+      await triggerAnalysisByStravaId(context.db, accessToken, stravaActivityId, user.id);
+    }
+  }
+  await computeAndStoreActivityLoad(context.db, user.id, activityId);
 }

--- a/src/services/strava_link_service.ts
+++ b/src/services/strava_link_service.ts
@@ -6,6 +6,7 @@ import { existingStravaIdsForUser } from "../repositories/activity_repository";
 import { activities } from "../schema";
 import type { IGlobalBindings } from "../types/IRouters";
 import type { SummaryActivity } from "../types/strava/IDetailedActivity";
+import { type MatchSubject, withinMatchTolerance } from "./activity_match";
 import { userHasHeartRateConsent } from "./heart_rate_consent_service";
 import { publishSync } from "./progress_service";
 import { type StravaRateLimit, stravaApiService } from "./strava_api_service";
@@ -21,9 +22,6 @@ const MAX_DESCRIPTION_FETCHES = 200;
 const PROGRESS_EVERY = 20;
 const DESC_PROGRESS_EVERY = 5;
 
-const TIME_TOLERANCE_MS = 5 * 60 * 1000;
-const DISTANCE_TOLERANCE_RATIO = 0.03;
-
 const SYNC_KIND = "strava_master_sync";
 const SYNC_TITLE = "Strava";
 
@@ -37,25 +35,24 @@ export interface StravaMasterSyncResult {
   failed: number;
 }
 
-type FuzzyLocal = {
+type FuzzyLocal = MatchSubject & {
   id: number;
-  startMs: number;
-  distance: number;
   descriptionResolved: boolean;
   intervalsStravaId: number | null;
 };
 
 function findUniqueMatch(summary: SummaryActivity, locals: FuzzyLocal[]): FuzzyLocal | null {
-  const startMs = new Date(summary.start_date_local).getTime();
-  if (Number.isNaN(startMs) || summary.distance == null) return null;
-
-  const minDistance = summary.distance * (1 - DISTANCE_TOLERANCE_RATIO);
-  const maxDistance = summary.distance * (1 + DISTANCE_TOLERANCE_RATIO);
+  const ref: MatchSubject = {
+    startMs: new Date(summary.start_date_local).getTime(),
+    distance: summary.distance,
+    movingTime: summary.moving_time ?? null,
+    sportType: summary.sport_type || summary.type,
+  };
+  if (Number.isNaN(ref.startMs)) return null;
 
   let found: FuzzyLocal | null = null;
   for (const local of locals) {
-    if (Math.abs(startMs - local.startMs) > TIME_TOLERANCE_MS) continue;
-    if (local.distance < minDistance || local.distance > maxDistance) continue;
+    if (!withinMatchTolerance(ref, local)) continue;
     if (found) return null;
     found = local;
   }
@@ -131,6 +128,8 @@ export async function syncAllFromStrava(
         id: activities.id,
         startDateLocal: activities.startDateLocal,
         distance: activities.distance,
+        movingTime: activities.movingTime,
+        sportType: activities.sportType,
         stravaActivityId: activities.stravaActivityId,
         intervalsStravaId: activities.intervalsStravaId,
         description: activities.description,
@@ -150,6 +149,8 @@ export async function syncAllFromStrava(
           id: row.id,
           startMs: row.startDateLocal.getTime(),
           distance: row.distance,
+          movingTime: row.movingTime,
+          sportType: row.sportType,
           descriptionResolved: row.description != null,
           intervalsStravaId: row.intervalsStravaId,
         });

--- a/tests/planned_session_resume.test.ts
+++ b/tests/planned_session_resume.test.ts
@@ -1,0 +1,143 @@
+// Planned-session matching runs AFTER the interrupt, so its state comes back
+// from the LangGraph checkpointer through JSON — `activityStartDateLocal` is an
+// ISO string, not a Date. A unit test with a hand-built Date state reproduces
+// nothing, which is exactly why this shipped broken (30/30 failures in prod).
+// This drives the real compiled graph through interrupt + resume.
+
+import { afterAll, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { eq } from "drizzle-orm";
+import { buildAnalysisGraph, resetAnalysisThread } from "../src/agent/analysis_graph";
+import * as eventAgent from "../src/agent/event_detection_agent";
+import * as initialAgent from "../src/agent/initial_analysis_agent";
+import type { WorkoutAnalysisOutput } from "../src/agent/initial_analysis_agent";
+import * as parseAgent from "../src/agent/parse_intervals_agent";
+import { plannedSessions } from "../src/schema";
+import * as deterministic from "../src/services/deterministic_segmenter";
+import * as paceService from "../src/services/pace_service";
+import { resumeAnalysis } from "../src/services/resume_analysis";
+import { stravaApiService } from "../src/services/strava_api_service";
+import type { StreamSet } from "../src/types/strava/IStream";
+import { createTestUser, deleteTestUser, getDb } from "./helpers/db";
+import {
+  insertActivity,
+  insertPlannedSession,
+  insertTrainingPlan,
+  insertTrainingPlanWeek,
+} from "./helpers/fixtures";
+
+const TOKEN = "test-strava-token";
+const SAMPLES = 1200;
+const ACTIVITY_DATE = "2026-02-10";
+const ACTIVITY_START_LOCAL = `${ACTIVITY_DATE}T08:00:00Z`;
+
+function buildStreams(): StreamSet {
+  return {
+    time: { data: Array.from({ length: SAMPLES }, (_, i) => i) },
+    distance: { data: Array.from({ length: SAMPLES }, (_, i) => i * 3) },
+    velocity_smooth: { data: Array.from({ length: SAMPLES }, () => 3) },
+  };
+}
+
+describe("matchPlannedSession after a real interrupt + resume", () => {
+  let userId: string;
+  const spies: { mockRestore: () => void }[] = [];
+  const db = () => getDb();
+
+  beforeAll(async () => {
+    const user = await createTestUser({ intervals: false });
+    userId = user.id;
+
+    spies.push(
+      spyOn(stravaApiService, "getActivity").mockResolvedValue({
+        id: 1,
+        name: "easy shakeout",
+        description: null,
+        trainer: false,
+        start_date_local: ACTIVITY_START_LOCAL,
+        type: "Run",
+        total_elevation_gain: 0,
+      } as never),
+      spyOn(stravaApiService, "getActivityStreams").mockResolvedValue(buildStreams() as never),
+      spyOn(stravaApiService, "getActivityLaps").mockResolvedValue([] as never),
+      spyOn(initialAgent, "invokeActivityAnalysisAgent").mockResolvedValue({
+        classification_reasoning: "stub",
+        confidence_score: 0.9,
+        intervals_description: null,
+        training_type: "EASY",
+        structure: [],
+      } as WorkoutAnalysisOutput as never),
+      spyOn(parseAgent, "invokeParseIntervalsAgent").mockResolvedValue({ sets: [] } as never),
+      spyOn(paceService, "getProposedPaceForStructure").mockResolvedValue([] as never),
+      spyOn(deterministic, "buildSegmentsDeterministic").mockReturnValue(null),
+      spyOn(eventAgent, "invokeEventDetectionAgent").mockResolvedValue({ events: [] } as never),
+    );
+  });
+
+  afterAll(async () => {
+    for (const s of spies) s.mockRestore();
+    await deleteTestUser(userId);
+  });
+
+  async function seedPlannedSession(date: string, sessionType: "EASY" | "LONG_INTERVALS") {
+    const plan = await insertTrainingPlan(userId, {
+      status: "active",
+      startDate: "2026-02-01",
+      endDate: "2026-03-01",
+    });
+    const week = await insertTrainingPlanWeek(plan.id, { startDate: "2026-02-09" });
+    return insertPlannedSession(plan.id, week.id, { date, sessionType, status: "planned" });
+  }
+
+  async function driveThroughResume(): Promise<number> {
+    const seeded = await insertActivity(userId, {
+      title: "easy shakeout",
+      description: "-",
+      analysisStatus: "pending",
+      trainingType: null,
+      sportType: "Run",
+      startDateLocal: new Date(ACTIVITY_START_LOCAL),
+    });
+    await resetAnalysisThread(seeded.id);
+    const graph = await buildAnalysisGraph();
+    await graph.invoke(
+      { activityId: seeded.id, stravaActivityId: seeded.stravaActivityId, userId },
+      {
+        configurable: {
+          thread_id: String(seeded.id),
+          db: db(),
+          stravaAccessToken: TOKEN,
+          intervalsAthleteId: null,
+        },
+      },
+    );
+    await resumeAnalysis(db(), TOKEN, seeded.id, "", [], "EASY", null, []);
+    await resetAnalysisThread(seeded.id);
+    return seeded.id;
+  }
+
+  it("links the matching planned session instead of throwing on the rehydrated date", async () => {
+    const session = await seedPlannedSession(ACTIVITY_DATE, "EASY");
+
+    const activityId = await driveThroughResume();
+
+    const [row] = await db()
+      .select()
+      .from(plannedSessions)
+      .where(eq(plannedSessions.id, session.id));
+    expect(row.completedActivityId).toBe(activityId);
+    expect(row.status).toBe("completed");
+  });
+
+  it("declines on merit — a far-off session is left planned", async () => {
+    const session = await seedPlannedSession("2026-02-20", "EASY");
+
+    await driveThroughResume();
+
+    const [row] = await db()
+      .select()
+      .from(plannedSessions)
+      .where(eq(plannedSessions.id, session.id));
+    expect(row.completedActivityId).toBeNull();
+    expect(row.status).toBe("planned");
+  });
+});

--- a/tests/process_strava_event.test.ts
+++ b/tests/process_strava_event.test.ts
@@ -12,7 +12,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { eq } from "drizzle-orm";
 import * as gearRepo from "../src/repositories/gear_repository";
 import { updateUserSettings } from "../src/repositories/user_settings_repository";
-import { activities, gears } from "../src/schema";
+import { activities, gears, users } from "../src/schema";
 import { progressService } from "../src/services/progress_service";
 import { stravaApiService } from "../src/services/strava_api_service";
 import { closePool, createTestUser, deleteTestUser, getDb } from "./helpers/db";
@@ -64,12 +64,23 @@ function createEvent(objectId: number, ownerId: number, aspect: "create" | "upda
   };
 }
 
+function athleteUpdateEvent(ownerId: number, updates: Record<string, string>) {
+  return {
+    object_type: "athlete" as const,
+    object_id: ownerId,
+    aspect_type: "update" as const,
+    owner_id: ownerId,
+    subscription_id: 999,
+    event_time: Math.floor(Date.now() / 1000),
+    updates,
+  };
+}
+
 async function createStravaUser(opts?: { lastSeenDaysAgo?: number; processHeartRate?: boolean }) {
   const user = await createTestUser({ role: "premium", processHeartRate: opts?.processHeartRate });
   const athleteId = nextAthleteId();
   const lastSeenAt =
     opts?.lastSeenDaysAgo != null ? new Date(Date.now() - opts.lastSeenDaysAgo * DAY_MS) : null;
-  const { users } = await import("../src/schema");
   await db
     .update(users)
     .set({ stravaId: String(athleteId), lastSeenAt })
@@ -596,6 +607,60 @@ describe("processStravaWebhook (real implementation)", () => {
         getActivityResult = stravaActivity(stravaActivityId, user.athleteId);
         await processStravaWebhook(createEvent(stravaActivityId, user.athleteId, "create"), context);
         expect(calls.count).toBe(0);
+      } finally {
+        await deleteTestUser(user.id);
+      }
+    });
+  });
+
+  // The athlete-update branch wipes every activity, zeroes gear counters and
+  // drops the token. Strava sends athlete-updates only for deauthorization
+  // today, but that is an undocumented assumption about a third party.
+  describe("athlete update (deauthorization)", () => {
+    async function seedForDeauth() {
+      const user = await createStravaUser();
+      await insertActivity(user.id, { sportType: "Run" });
+      return user;
+    }
+
+    it("deletes nothing when the payload is not a deauthorization", async () => {
+      const user = await seedForDeauth();
+      try {
+        await processStravaWebhook(athleteUpdateEvent(user.athleteId, { weight: "72.5" }), context);
+
+        expect(await activitiesFor(user.id)).toHaveLength(1);
+        const [row] = await db.select().from(users).where(eq(users.id, user.id));
+        expect(row.stravaId).toBe(String(user.athleteId));
+      } finally {
+        await deleteTestUser(user.id);
+      }
+    });
+
+    it("deletes nothing when `authorized` is present but true", async () => {
+      const user = await seedForDeauth();
+      try {
+        await processStravaWebhook(
+          athleteUpdateEvent(user.athleteId, { authorized: "true" }),
+          context,
+        );
+
+        expect(await activitiesFor(user.id)).toHaveLength(1);
+      } finally {
+        await deleteTestUser(user.id);
+      }
+    });
+
+    it("still wipes the account on the real deauthorization payload", async () => {
+      const user = await seedForDeauth();
+      try {
+        await processStravaWebhook(
+          athleteUpdateEvent(user.athleteId, { authorized: "false" }),
+          context,
+        );
+
+        expect(await activitiesFor(user.id)).toHaveLength(0);
+        const [row] = await db.select().from(users).where(eq(users.id, user.id));
+        expect(row.stravaId).toBeNull();
       } finally {
         await deleteTestUser(user.id);
       }

--- a/tests/webhook_cross_provider.test.ts
+++ b/tests/webhook_cross_provider.test.ts
@@ -1,0 +1,418 @@
+// One workout arriving from BOTH providers. Every other webhook suite drives a
+// single provider (the existing "fuzzy merge" case seeds the intervals row
+// directly rather than driving its handler), so cross-source dedup was never
+// covered end-to-end — which is how the zero-distance hole shipped.
+//
+// Both real handlers are loaded via the query-suffix specifier that bypasses the
+// global no-op mocks in tests/setup.ts; the provider API objects are
+// monkeypatched and restored per test (the strava_dedup.test.ts pattern).
+
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { eq } from "drizzle-orm";
+import { activities, users } from "../src/schema";
+import { intervalsApiService } from "../src/services/intervals_api_service";
+import { stravaApiService } from "../src/services/strava_api_service";
+import { closePool, createTestUser, deleteTestUser, getDb } from "./helpers/db";
+import { synthIntervalsActivity } from "./helpers/intervals_fixtures";
+
+const realStrava = "../src/services/process_strava_event.ts?real=1";
+const realIntervals = "../src/services/process_intervals_event.ts?real=1";
+const { processStravaWebhook } = (await import(
+  realStrava
+)) as typeof import("../src/services/process_strava_event");
+const { processIntervalsWebhook } = (await import(
+  realIntervals
+)) as typeof import("../src/services/process_intervals_event");
+
+const db = getDb();
+const context = { db } as never;
+
+// The observed 2229/2230 pair: one elliptical, two providers, five minutes apart.
+const START_LOCAL = "2026-07-21T13:24:31";
+
+let seq = 500_000 + Math.floor(Math.random() * 100_000);
+const nextId = () => ++seq;
+
+async function createDualUser() {
+  const user = await createTestUser({ role: "premium" });
+  const athleteId = nextId();
+  const intervalsAthleteId = `i-ath-x${athleteId}`;
+  await db
+    .update(users)
+    .set({ stravaId: String(athleteId), intervalsAthleteId })
+    .where(eq(users.id, user.id));
+  return { ...user, athleteId, intervalsAthleteId };
+}
+
+const activitiesFor = (userId: string) =>
+  db.select().from(activities).where(eq(activities.userId, userId));
+
+function stravaEvent(
+  objectId: number,
+  ownerId: number,
+  aspect: "create" | "update" | "delete",
+  updates: Record<string, string> = {},
+) {
+  return {
+    object_type: "activity" as const,
+    object_id: objectId,
+    aspect_type: aspect,
+    owner_id: ownerId,
+    subscription_id: 999,
+    event_time: Math.floor(Date.now() / 1000),
+    updates,
+  };
+}
+
+function intervalsEvent(type: string, athleteId: string, activityId: string) {
+  return { type, athlete_id: athleteId, activity: { id: activityId } } as never;
+}
+
+function stravaActivity(id: number, athleteId: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    athlete: { id: athleteId },
+    name: "Afternoon Elliptical",
+    description: "",
+    sport_type: "Elliptical",
+    type: "Elliptical",
+    distance: 0,
+    moving_time: 1806,
+    total_elevation_gain: 0,
+    start_date_local: `${START_LOCAL}Z`,
+    has_heartrate: false,
+    gear_id: null,
+    trainer: true,
+    splits_metric: [],
+    ...overrides,
+  };
+}
+
+function intervalsActivity(overrides: Record<string, unknown> = {}) {
+  return synthIntervalsActivity({
+    name: "Elliptical",
+    type: "Elliptical",
+    start_date: START_LOCAL,
+    start_date_local: START_LOCAL,
+    moving_time: 1805,
+    elapsed_time: 1805,
+    distance: 0,
+    total_elevation_gain: 0,
+    trainer: false,
+    ...overrides,
+  });
+}
+
+const realStravaGetActivity = stravaApiService.getActivity;
+const realIntervalsGetActivity = intervalsApiService.getActivity;
+let stravaResult: unknown;
+let intervalsResult: unknown;
+
+beforeEach(() => {
+  stravaApiService.getActivity = (async () =>
+    stravaResult) as typeof stravaApiService.getActivity;
+  intervalsApiService.getActivity = (async () =>
+    intervalsResult) as typeof intervalsApiService.getActivity;
+});
+
+afterEach(() => {
+  stravaApiService.getActivity = realStravaGetActivity;
+  intervalsApiService.getActivity = realIntervalsGetActivity;
+  stravaResult = undefined;
+  intervalsResult = undefined;
+});
+
+afterAll(async () => {
+  await closePool();
+});
+
+describe("cross-provider ingest — one workout, both webhooks", () => {
+  it("zero-distance elliptical: intervals UPLOADED then Strava create collapses to one row", async () => {
+    const user = await createDualUser();
+    try {
+      const icu = intervalsActivity();
+      const stravaId = nextId() * 1000;
+      intervalsResult = icu;
+      stravaResult = stravaActivity(stravaId, user.athleteId);
+
+      await processIntervalsWebhook(
+        intervalsEvent("ACTIVITY_UPLOADED", user.intervalsAthleteId, icu.id),
+        context,
+      );
+      expect(await activitiesFor(user.id)).toHaveLength(1);
+
+      await processStravaWebhook(stravaEvent(stravaId, user.athleteId, "create"), context);
+
+      const rows = await activitiesFor(user.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].intervalsIcuId).toBe(icu.id);
+      expect(rows[0].stravaActivityId).toBe(stravaId);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("zero-distance elliptical: Strava create then intervals UPLOADED collapses to one row", async () => {
+    const user = await createDualUser();
+    try {
+      const icu = intervalsActivity();
+      const stravaId = nextId() * 1000;
+      intervalsResult = icu;
+      stravaResult = stravaActivity(stravaId, user.athleteId);
+
+      await processStravaWebhook(stravaEvent(stravaId, user.athleteId, "create"), context);
+      expect(await activitiesFor(user.id)).toHaveLength(1);
+
+      await processIntervalsWebhook(
+        intervalsEvent("ACTIVITY_UPLOADED", user.intervalsAthleteId, icu.id),
+        context,
+      );
+
+      const rows = await activitiesFor(user.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].intervalsIcuId).toBe(icu.id);
+      expect(rows[0].stravaActivityId).toBe(stravaId);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("distance-bearing run: intervals UPLOADED then Strava create collapses to one row", async () => {
+    const user = await createDualUser();
+    try {
+      const icu = intervalsActivity({ type: "Run", distance: 8000, moving_time: 2400 });
+      const stravaId = nextId() * 1000;
+      intervalsResult = icu;
+      stravaResult = stravaActivity(stravaId, user.athleteId, {
+        sport_type: "Run",
+        type: "Run",
+        distance: 8010,
+        moving_time: 2399,
+      });
+
+      await processIntervalsWebhook(
+        intervalsEvent("ACTIVITY_UPLOADED", user.intervalsAthleteId, icu.id),
+        context,
+      );
+      await processStravaWebhook(stravaEvent(stravaId, user.athleteId, "create"), context);
+
+      const rows = await activitiesFor(user.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].stravaActivityId).toBe(stravaId);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("distance-bearing run: Strava create then intervals UPLOADED collapses to one row", async () => {
+    const user = await createDualUser();
+    try {
+      const icu = intervalsActivity({ type: "Run", distance: 8000, moving_time: 2400 });
+      const stravaId = nextId() * 1000;
+      intervalsResult = icu;
+      stravaResult = stravaActivity(stravaId, user.athleteId, {
+        sport_type: "Run",
+        type: "Run",
+        distance: 8010,
+        moving_time: 2399,
+      });
+
+      await processStravaWebhook(stravaEvent(stravaId, user.athleteId, "create"), context);
+      await processIntervalsWebhook(
+        intervalsEvent("ACTIVITY_UPLOADED", user.intervalsAthleteId, icu.id),
+        context,
+      );
+
+      const rows = await activitiesFor(user.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].intervalsIcuId).toBe(icu.id);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("a zero-distance row does not swallow a real-distance activity in the same window", async () => {
+    const user = await createDualUser();
+    try {
+      const icu = intervalsActivity();
+      const stravaId = nextId() * 1000;
+      intervalsResult = icu;
+      stravaResult = stravaActivity(stravaId, user.athleteId, {
+        sport_type: "Run",
+        type: "Run",
+        distance: 10_000,
+        moving_time: 1805,
+      });
+
+      await processIntervalsWebhook(
+        intervalsEvent("ACTIVITY_UPLOADED", user.intervalsAthleteId, icu.id),
+        context,
+      );
+      await processStravaWebhook(stravaEvent(stravaId, user.athleteId, "create"), context);
+
+      expect(await activitiesFor(user.id)).toHaveLength(2);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("two different zero-distance sports in the same window stay separate", async () => {
+    const user = await createDualUser();
+    try {
+      const icu = intervalsActivity();
+      const stravaId = nextId() * 1000;
+      intervalsResult = icu;
+      stravaResult = stravaActivity(stravaId, user.athleteId, {
+        sport_type: "Rowing",
+        type: "Rowing",
+      });
+
+      await processIntervalsWebhook(
+        intervalsEvent("ACTIVITY_UPLOADED", user.intervalsAthleteId, icu.id),
+        context,
+      );
+      await processStravaWebhook(stravaEvent(stravaId, user.athleteId, "create"), context);
+
+      expect(await activitiesFor(user.id)).toHaveLength(2);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("same zero-distance sport but a very different duration stays separate", async () => {
+    const user = await createDualUser();
+    try {
+      const icu = intervalsActivity({ moving_time: 1805 });
+      const stravaId = nextId() * 1000;
+      intervalsResult = icu;
+      stravaResult = stravaActivity(stravaId, user.athleteId, { moving_time: 3600 });
+
+      await processIntervalsWebhook(
+        intervalsEvent("ACTIVITY_UPLOADED", user.intervalsAthleteId, icu.id),
+        context,
+      );
+      await processStravaWebhook(stravaEvent(stravaId, user.athleteId, "create"), context);
+
+      expect(await activitiesFor(user.id)).toHaveLength(2);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("redelivery of both providers' events after a merge still yields one row", async () => {
+    const user = await createDualUser();
+    try {
+      const icu = intervalsActivity();
+      const stravaId = nextId() * 1000;
+      intervalsResult = icu;
+      stravaResult = stravaActivity(stravaId, user.athleteId);
+
+      const uploaded = intervalsEvent("ACTIVITY_UPLOADED", user.intervalsAthleteId, icu.id);
+      const created = stravaEvent(stravaId, user.athleteId, "create");
+
+      await processIntervalsWebhook(uploaded, context);
+      await processStravaWebhook(created, context);
+      await processIntervalsWebhook(uploaded, context);
+      await processStravaWebhook(created, context);
+
+      expect(await activitiesFor(user.id)).toHaveLength(1);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+});
+
+describe("orphan Strava update (no local row yet)", () => {
+  it("creates exactly one row instead of silently dropping the activity", async () => {
+    const user = await createDualUser();
+    try {
+      const stravaId = nextId() * 1000;
+      stravaResult = stravaActivity(stravaId, user.athleteId, {
+        sport_type: "Run",
+        type: "Run",
+        distance: 8000,
+        moving_time: 2400,
+        name: "Edited title",
+      });
+
+      await processStravaWebhook(
+        stravaEvent(stravaId, user.athleteId, "update", { title: "Edited title" }),
+        context,
+      );
+
+      const rows = await activitiesFor(user.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].stravaActivityId).toBe(stravaId);
+      expect(rows[0].title).toBe("Edited title");
+      expect(rows[0].analysisStatus).toBe("pending");
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("racing a real create still yields exactly one row", async () => {
+    const user = await createDualUser();
+    try {
+      const stravaId = nextId() * 1000;
+      stravaResult = stravaActivity(stravaId, user.athleteId, {
+        sport_type: "Run",
+        type: "Run",
+        distance: 8000,
+        moving_time: 2400,
+      });
+
+      await Promise.all([
+        processStravaWebhook(stravaEvent(stravaId, user.athleteId, "create"), context),
+        processStravaWebhook(
+          stravaEvent(stravaId, user.athleteId, "update", { title: "Edited title" }),
+          context,
+        ),
+      ]);
+
+      expect(await activitiesFor(user.id)).toHaveLength(1);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("merges into an existing intervals.icu twin rather than inserting", async () => {
+    const user = await createDualUser();
+    try {
+      const icu = intervalsActivity();
+      const stravaId = nextId() * 1000;
+      intervalsResult = icu;
+      stravaResult = stravaActivity(stravaId, user.athleteId);
+
+      await processIntervalsWebhook(
+        intervalsEvent("ACTIVITY_UPLOADED", user.intervalsAthleteId, icu.id),
+        context,
+      );
+
+      await processStravaWebhook(
+        stravaEvent(stravaId, user.athleteId, "update", { title: "Afternoon Elliptical" }),
+        context,
+      );
+
+      const rows = await activitiesFor(user.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].intervalsIcuId).toBe(icu.id);
+      expect(rows[0].stravaActivityId).toBe(stravaId);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+
+  it("a delete arriving before its create stays a no-op", async () => {
+    const user = await createDualUser();
+    try {
+      const stravaId = nextId() * 1000;
+      stravaResult = stravaActivity(stravaId, user.athleteId);
+
+      await processStravaWebhook(stravaEvent(stravaId, user.athleteId, "delete"), context);
+
+      expect(await activitiesFor(user.id)).toHaveLength(0);
+    } finally {
+      await deleteTestUser(user.id);
+    }
+  });
+});


### PR DESCRIPTION
…, deauth guard

P1 narrows activityStartDateLocal to Date|string — the LangGraph checkpointer round-trips it through JSON, so every post-interrupt node saw a string while the annotation claimed Date. Covered by a test that drives the real graph through interrupt + resume (a hand-built Date state reproduces nothing).

P2 makes activity matching fall back to a duration band + sport match when both sides have distance <= 0. Elliptical/WeightTraining/Yoga/pool-Swim store distance 0 from every provider, so the distance-only comparison could never merge them. All five fuzzy-match sites now route through withinMatchTolerance; strava_link_service no longer redeclares the tolerance constants.

P2b makes an orphan Strava update create the row instead of silently dropping it, sharing one dedup implementation with the create branch and serializing both behind pg_advisory_xact_lock (they arrive seconds apart, both fire-and-forget).

P3 requires updates.authorized === "false" before the account-wiping deauth branch.